### PR TITLE
Restructure test calendars

### DIFF
--- a/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -118,8 +118,12 @@ describe('TeamContributionCalendar', () => {
     let setEmptyCalendarValuesStub;
     let updateCalendarStub;
 
-    const defaultUserJsonCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts([5])[0];
-    const defaultUserEmptyCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts([0])[0];
+    const defaultUserJsonCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts({
+      '2019-01-20': 12,
+    });
+    const defaultUserEmptyCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts({
+      '2019-01-20': 0,
+    });
 
     beforeEach(() => {
       getJsonFormattedCalendarSyncStub = sandbox.stub(GitHubUtils, 'getJsonFormattedCalendarSync').returns(defaultUserJsonCalendar);
@@ -175,7 +179,9 @@ describe('TeamContributionCalendar', () => {
 
     const data = {
       contributions: 1024,
-      updatedActualCalendar: TestUtils.getFakeContributionsObjectWithDailyCounts([4])[0],
+      updatedActualCalendar: TestUtils.getFakeContributionsObjectWithDailyCounts({
+        '2018-10-10': 12,
+      }),
     };
 
     beforeEach(() => {
@@ -240,7 +246,9 @@ describe('TeamContributionCalendar', () => {
       let getJsonFormattedCalendarAsyncStub;
       let processGitHubCalendarStub;
 
-      const gitHubUserJsonCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts([5])[0];
+      const gitHubUserJsonCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts({
+        '2017-05-22': 10,
+      });
 
       beforeEach(() => {
         getJsonFormattedCalendarAsyncStub = sandbox.stub(GitHubUtils, 'getJsonFormattedCalendarAsync').returns(gitHubUserJsonCalendar);
@@ -275,8 +283,15 @@ describe('TeamContributionCalendar', () => {
     let getLastYearContributionsStub;
     let updateCalendarStub;
 
-    const gitHubUserJsonCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts([4])[0];
-    const updatedActualCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts([12])[0];
+    const gitHubUserJsonCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts({
+      '2019-03-10': 15,
+      '2019-03-12': 5,
+    });
+    const updatedActualCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts({
+      '2019-03-10': 18,
+      '2019-03-11': 15,
+      '2019-03-12': 7,
+    });
     const contributions = 1024;
 
     beforeEach(() => {

--- a/src/utils/CalendarUtils/CalendarUtils.test.js
+++ b/src/utils/CalendarUtils/CalendarUtils.test.js
@@ -120,7 +120,9 @@ describe('CalendarUtils', () => {
   });
 
   describe('getCalendarDataByIndexes', () => {
-    const calendarData = TestUtils.getFakeContributionsObjectWithDailyCounts([12])[0];
+    const calendarData = TestUtils.getFakeContributionsObjectWithDailyCounts({
+      '2019-04-20': 15,
+    });
     const weekIndex = 0;
 
     describe('when the day index is defined', () => {

--- a/src/utils/GitHubUtils/GitHubUtils.test.js
+++ b/src/utils/GitHubUtils/GitHubUtils.test.js
@@ -5,7 +5,7 @@ import * as TestUtils from '../TestUtils/TestUtils';
 describe('GitHubUtils', () => {
   describe('setEmptyCalendarValues', () => {
     const calendar = TestUtils.getFakeContributionsObjectWithDailyCounts({
-      '2019-05-20': 5,
+      '2019-03-21': 5,
     });
 
     it('sets the daily contributions to zero', () => {
@@ -32,7 +32,7 @@ describe('GitHubUtils', () => {
       '2019-04-19': 5,
     });
     const userJsonCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts({
-      '2019-04-20': 6,
+      '2019-04-19': 6,
     });
 
     it('merges the `data-count` properties of the given calendars', () => {

--- a/src/utils/GitHubUtils/GitHubUtils.test.js
+++ b/src/utils/GitHubUtils/GitHubUtils.test.js
@@ -4,13 +4,15 @@ import * as TestUtils from '../TestUtils/TestUtils';
 
 describe('GitHubUtils', () => {
   describe('setEmptyCalendarValues', () => {
-    const calendar = TestUtils.getFakeContributionsObjectWithDailyCounts([5])[0];
+    const calendar = TestUtils.getFakeContributionsObjectWithDailyCounts({
+      '2019-05-20': 5,
+    });
 
     it('sets the daily contributions to zero', () => {
-      const expectedContributionsValue = '0';
+      const expectedContributionsValue = 0;
 
       const restoredCalendar = GitHubUtils.setEmptyCalendarValues(calendar);
-      const actualContributionsValue = restoredCalendar.children[0].children[0].children[0].attributes['data-count'];
+      const actualContributionsValue = Number(restoredCalendar.children[0].children[0].children[0].attributes['data-count']);
 
       expect(actualContributionsValue).to.equal(expectedContributionsValue);
     });
@@ -26,28 +28,37 @@ describe('GitHubUtils', () => {
   });
 
   describe('mergeCalendarsContributions', () => {
-    const actualCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts([5])[0];
-    const userJsonCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts([6])[0];
+    const actualCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts({
+      '2019-04-19': 5,
+    });
+    const userJsonCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts({
+      '2019-04-20': 6,
+    });
 
     it('merges the `data-count` properties of the given calendars', () => {
       // Because of the previously created 5 and 6 contribution calendars.
-      const expectedDataCountValue = '11';
+      const expectedDataCountValue = 11;
 
       const mergedCalendar = GitHubUtils.mergeCalendarsContributions(
         actualCalendar, userJsonCalendar,
       );
-      const actualDataCountValue = mergedCalendar.children[0].children[0].children[0]
-        .attributes['data-count'];
+
+      const actualDataCountValue = Number(mergedCalendar.children[0].children[0].children[0]
+        .attributes['data-count']);
 
       expect(actualDataCountValue).to.equal(expectedDataCountValue);
     });
   });
 
   describe('getLastYearContributions', () => {
-    const userJsonCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts([5])[0];
+    const userJsonCalendar = TestUtils.getFakeContributionsObjectWithDailyCounts({
+      '2019-01-20': 5,
+      '2019-01-25': 12,
+      '2019-01-26': 15,
+    });
 
     it('returns the given user last year contributions', () => {
-      const expectedLastYearContributions = 5;
+      const expectedLastYearContributions = 32;
 
       const actualLastYearContributions = GitHubUtils.getLastYearContributions(userJsonCalendar);
 

--- a/src/utils/TestUtils/TestUtils.js
+++ b/src/utils/TestUtils/TestUtils.js
@@ -1,27 +1,37 @@
-export const getFakeContributionsObjectWithDailyCounts = dailyCounts => dailyCounts.map(count => ({
+const getInitialCalendar = () => ({
   children: [
     {
       children: [
         {
-          children: [
-            {
-              attributes: {
-                class: 'day',
-                'data-count': count,
-                'data-date': '2018-03-18',
-                fill: '#ebedf0',
-                height: '10',
-                width: '10',
-                x: '13',
-                y: '0',
-              },
-            },
-          ],
+          children: [],
         },
       ],
     },
   ],
-}));
+});
+
+const getDailyAttribute = (date, contributions) => ({
+  class: 'day',
+  'data-count': String(contributions),
+  'data-date': date,
+  fill: '#ebedf0',
+  height: '10',
+  width: '10',
+  x: '13',
+  y: '0',
+});
+
+export const getFakeContributionsObjectWithDailyCounts = (dailyDataWithContributions) => {
+  const fakeContributionsObjectWithDailyCounts = getInitialCalendar();
+
+  Object.keys(dailyDataWithContributions).forEach((date) => {
+    fakeContributionsObjectWithDailyCounts.children[0].children[0].children.push({
+      attributes: getDailyAttribute(date, dailyDataWithContributions[date]),
+    });
+  });
+
+  return fakeContributionsObjectWithDailyCounts;
+};
 
 export const getTestParams = () => ({
   container: '.container',


### PR DESCRIPTION
No relevant issue.

Based on our [**discussion**](https://github.com/c-hive/team-contribution-calendar/pull/16#discussion_r276952073) with @thisismydesign, the way of generating fake/test calendars has been restructured. It currently accepts an object in the following format - instead of the previous version in which the passed argument was an array of contributions:
```
{
   '2019-02-03': 5,
   '2019-02-04': 11',
   // ...
}
```

Put simply, it returns the same object that we'd expect in our tests - and not an array of single-day elements.
