### PR TITLE
Hover effect

### DIFF
--- a/src/resources/TeamContributionCalendar/TeamContributionCalendar.js
+++ b/src/resources/TeamContributionCalendar/TeamContributionCalendar.js
@@ -3,6 +3,7 @@ import * as GetStyledCalendarElement from '../../utils/GetStyledCalendarElement/
 import * as GitHubUtils from '../../utils/GitHubUtils/GitHubUtils';
 import * as GitLabUtils from '../../utils/GitLabUtils/GitLabUtils';
 import * as JavaScriptUtils from '../../utils/JavaScriptUtils/JavaScriptUtils';
+import * as Tooltip from '../../utils/Tooltip/Tooltip';
 import BasicCalendar from '../BasicCalendar/BasicCalendar.json';
 import * as DefaultUsers from '../DefaultUsers/DefaultUsers';
 
@@ -64,6 +65,8 @@ export default class TeamContributionCalendar {
     calendarContainer.innerHTML = stringifiedHTMLContent;
     calendarContainer.prepend(calendarHeader);
     calendarContainer.appendChild(calendarTooltip);
+
+    Tooltip.addEvents();
   }
 
   aggregateUserCalendars() {

--- a/src/resources/TeamContributionCalendar/TeamContributionCalendar.js
+++ b/src/resources/TeamContributionCalendar/TeamContributionCalendar.js
@@ -57,11 +57,13 @@ export default class TeamContributionCalendar {
   renderActualCalendar() {
     const calendarContainer = GetStyledCalendarElement.container(this.configs.container);
     const calendarHeader = GetStyledCalendarElement.header(this.totalContributions, this.isLoading);
+    const calendarTooltip = GetStyledCalendarElement.tooltip();
 
     const stringifiedHTMLContent = stringify(this.actualCalendar);
 
     calendarContainer.innerHTML = stringifiedHTMLContent;
     calendarContainer.prepend(calendarHeader);
+    calendarContainer.appendChild(calendarTooltip);
   }
 
   aggregateUserCalendars() {

--- a/src/resources/TeamContributionCalendar/TeamContributionCalendar.js
+++ b/src/resources/TeamContributionCalendar/TeamContributionCalendar.js
@@ -66,7 +66,7 @@ export default class TeamContributionCalendar {
     calendarContainer.prepend(calendarHeader);
     calendarContainer.appendChild(calendarTooltip);
 
-    Tooltip.addEvents();
+    Tooltip.addEventsToRectElements();
   }
 
   aggregateUserCalendars() {

--- a/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -64,7 +64,7 @@ describe('TeamContributionCalendar', () => {
     let headerStub;
     let tooltipStub;
 
-    let addEventsStub;
+    let addEventsToRectElementsStub;
 
     let appendChildSpy;
     let prependSpy;
@@ -91,7 +91,7 @@ describe('TeamContributionCalendar', () => {
       headerStub = sandbox.stub(GetStyledCalendarElement, 'header').returns(calendarHeader);
       tooltipStub = sandbox.stub(GetStyledCalendarElement, 'tooltip').returns(calendarTooltip);
 
-      addEventsStub = sandbox.stub(Tooltip, 'addEvents');
+      addEventsToRectElementsStub = sandbox.stub(Tooltip, 'addEventsToRectElements');
     });
 
     it('renders the styled container into the given element', () => {
@@ -136,7 +136,7 @@ describe('TeamContributionCalendar', () => {
     it('adds the tooltip events to the `rect` elements', () => {
       teamContributionCalendar.renderActualCalendar();
 
-      expect(addEventsStub.calledOnce).to.equal(true);
+      expect(addEventsToRectElementsStub.calledOnce).to.equal(true);
     });
   });
 

--- a/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -1,15 +1,19 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import jsdom from 'mocha-jsdom';
 import TeamContributionCalendar from './TeamContributionCalendar';
 import * as GetStyledCalendarElement from '../../utils/GetStyledCalendarElement/GetStyledCalendarElement';
 import * as GitHubUtils from '../../utils/GitHubUtils/GitHubUtils';
 import * as GitLabUtils from '../../utils/GitLabUtils/GitLabUtils';
 import * as TestUtils from '../../utils/TestUtils/TestUtils';
-import * as Tooltip from '../../utils/Tooltip/Tooltip';
 import BasicCalendar from '../BasicCalendar/BasicCalendar.json';
 import * as DefaultUsers from '../DefaultUsers/DefaultUsers';
 
 describe('TeamContributionCalendar', () => {
+  jsdom({
+    url: 'https://example.org/',
+  });
+
   const sandbox = sinon.createSandbox();
 
   let teamContributionCalendar;
@@ -60,8 +64,6 @@ describe('TeamContributionCalendar', () => {
   });
 
   describe('renderActualCalendar', () => {
-    let addEventsToRectElementsStub;
-
     let appendChildSpy;
     let prependSpy;
 
@@ -86,8 +88,6 @@ describe('TeamContributionCalendar', () => {
       sandbox.stub(GetStyledCalendarElement, 'container').returns(calendarContainer);
       sandbox.stub(GetStyledCalendarElement, 'header').returns(calendarHeader);
       sandbox.stub(GetStyledCalendarElement, 'tooltip').returns(calendarTooltip);
-
-      addEventsToRectElementsStub = sandbox.stub(Tooltip, 'addEventsToRectElements');
     });
 
     it('prepends the header to the container', () => {
@@ -104,12 +104,6 @@ describe('TeamContributionCalendar', () => {
       expect(calendarContainer.appendChild.calledWithExactly(
         calendarTooltip,
       )).to.equal(true);
-    });
-
-    it('calls `addEventsToRectElements`', () => {
-      teamContributionCalendar.renderActualCalendar();
-
-      expect(addEventsToRectElementsStub.calledOnce).to.equal(true);
     });
   });
 

--- a/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -5,6 +5,7 @@ import * as GetStyledCalendarElement from '../../utils/GetStyledCalendarElement/
 import * as GitHubUtils from '../../utils/GitHubUtils/GitHubUtils';
 import * as GitLabUtils from '../../utils/GitLabUtils/GitLabUtils';
 import * as TestUtils from '../../utils/TestUtils/TestUtils';
+import * as Tooltip from '../../utils/Tooltip/Tooltip';
 import BasicCalendar from '../BasicCalendar/BasicCalendar.json';
 import * as DefaultUsers from '../DefaultUsers/DefaultUsers';
 
@@ -63,6 +64,8 @@ describe('TeamContributionCalendar', () => {
     let headerStub;
     let tooltipStub;
 
+    let addEventsStub;
+
     let appendChildSpy;
     let prependSpy;
 
@@ -87,6 +90,8 @@ describe('TeamContributionCalendar', () => {
       containerStub = sandbox.stub(GetStyledCalendarElement, 'container').returns(calendarContainer);
       headerStub = sandbox.stub(GetStyledCalendarElement, 'header').returns(calendarHeader);
       tooltipStub = sandbox.stub(GetStyledCalendarElement, 'tooltip').returns(calendarTooltip);
+
+      addEventsStub = sandbox.stub(Tooltip, 'addEvents');
     });
 
     it('renders the styled container into the given element', () => {
@@ -126,6 +131,12 @@ describe('TeamContributionCalendar', () => {
       expect(calendarContainer.appendChild.calledWithExactly(
         calendarTooltip,
       )).to.equal(true);
+    });
+
+    it('adds the tooltip events to the `rect` elements', () => {
+      teamContributionCalendar.renderActualCalendar();
+
+      expect(addEventsStub.calledOnce).to.equal(true);
     });
   });
 

--- a/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -60,10 +60,6 @@ describe('TeamContributionCalendar', () => {
   });
 
   describe('renderActualCalendar', () => {
-    let containerStub;
-    let headerStub;
-    let tooltipStub;
-
     let addEventsToRectElementsStub;
 
     let appendChildSpy;
@@ -87,28 +83,11 @@ describe('TeamContributionCalendar', () => {
         appendChild: appendChildSpy,
       };
 
-      containerStub = sandbox.stub(GetStyledCalendarElement, 'container').returns(calendarContainer);
-      headerStub = sandbox.stub(GetStyledCalendarElement, 'header').returns(calendarHeader);
-      tooltipStub = sandbox.stub(GetStyledCalendarElement, 'tooltip').returns(calendarTooltip);
+      sandbox.stub(GetStyledCalendarElement, 'container').returns(calendarContainer);
+      sandbox.stub(GetStyledCalendarElement, 'header').returns(calendarHeader);
+      sandbox.stub(GetStyledCalendarElement, 'tooltip').returns(calendarTooltip);
 
       addEventsToRectElementsStub = sandbox.stub(Tooltip, 'addEventsToRectElements');
-    });
-
-    it('renders the styled container into the given element', () => {
-      teamContributionCalendar.renderActualCalendar();
-
-      expect(containerStub.calledWithExactly(
-        teamContributionCalendar.configs.container,
-      )).to.equal(true);
-    });
-
-    it('gets the styled calendar header', () => {
-      teamContributionCalendar.renderActualCalendar();
-
-      expect(headerStub.calledWithExactly(
-        teamContributionCalendar.totalContributions,
-        teamContributionCalendar.isLoading,
-      )).to.equal(true);
     });
 
     it('prepends the header to the container', () => {
@@ -119,12 +98,6 @@ describe('TeamContributionCalendar', () => {
       )).to.equal(true);
     });
 
-    it('gets the tooltip element', () => {
-      teamContributionCalendar.renderActualCalendar();
-
-      expect(tooltipStub.calledOnce).to.equal(true);
-    });
-
     it('appends the tooltip element to the container', () => {
       teamContributionCalendar.renderActualCalendar();
 
@@ -133,7 +106,7 @@ describe('TeamContributionCalendar', () => {
       )).to.equal(true);
     });
 
-    it('adds the tooltip events to the `rect` elements', () => {
+    it('calls `addEventsToRectElements`', () => {
       teamContributionCalendar.renderActualCalendar();
 
       expect(addEventsToRectElementsStub.calledOnce).to.equal(true);

--- a/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/resources/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -61,12 +61,14 @@ describe('TeamContributionCalendar', () => {
   describe('renderActualCalendar', () => {
     let containerStub;
     let headerStub;
+    let tooltipStub;
 
     let appendChildSpy;
     let prependSpy;
 
     let calendarContainer;
     let calendarHeader;
+    let calendarTooltip;
 
     beforeEach(() => {
       appendChildSpy = sandbox.spy();
@@ -74,6 +76,7 @@ describe('TeamContributionCalendar', () => {
 
       calendarContainer = {
         prepend: prependSpy,
+        appendChild: appendChildSpy,
         innerHTML: null,
       };
 
@@ -83,6 +86,7 @@ describe('TeamContributionCalendar', () => {
 
       containerStub = sandbox.stub(GetStyledCalendarElement, 'container').returns(calendarContainer);
       headerStub = sandbox.stub(GetStyledCalendarElement, 'header').returns(calendarHeader);
+      tooltipStub = sandbox.stub(GetStyledCalendarElement, 'tooltip').returns(calendarTooltip);
     });
 
     it('renders the styled container into the given element', () => {
@@ -107,6 +111,20 @@ describe('TeamContributionCalendar', () => {
 
       expect(calendarContainer.prepend.calledWithExactly(
         calendarHeader,
+      )).to.equal(true);
+    });
+
+    it('gets the tooltip element', () => {
+      teamContributionCalendar.renderActualCalendar();
+
+      expect(tooltipStub.calledOnce).to.equal(true);
+    });
+
+    it('appends the tooltip element to the container', () => {
+      teamContributionCalendar.renderActualCalendar();
+
+      expect(calendarContainer.appendChild.calledWithExactly(
+        calendarTooltip,
       )).to.equal(true);
     });
   });

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
@@ -108,19 +108,19 @@ const getDateText = (date) => {
 };
 
 export const contributionsWithDateText = (contributions, date) => {
-  const tooltipText = document.createElement('SPAN');
+  const tooltipInnerText = document.createElement('SPAN');
 
-  tooltipText.style.color = '#FFFFFF';
-  tooltipText.style.fontWeight = 'bold';
-  tooltipText.innerText = 'No contributions';
+  tooltipInnerText.style.color = '#FFFFFF';
+  tooltipInnerText.style.fontWeight = 'bold';
+  tooltipInnerText.innerText = 'No contributions';
 
   if (contributions > 0) {
-    tooltipText.innerText = `${contributions} contributions`;
+    tooltipInnerText.innerText = `${contributions} contributions`;
   }
 
   const dateText = getDateText(date);
 
-  tooltipText.appendChild(dateText);
+  tooltipInnerText.appendChild(dateText);
 
-  return tooltipText;
+  return tooltipInnerText;
 };

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
@@ -97,7 +97,7 @@ export const tooltip = () => {
   return calendarTooltip;
 };
 
-const getContributionsDateText = (date) => {
+const getDateText = (date) => {
   const contributionsDateText = document.createElement('SPAN');
 
   contributionsDateText.style.color = '#959DA5';
@@ -107,7 +107,7 @@ const getContributionsDateText = (date) => {
   return contributionsDateText;
 };
 
-export const tooltipContributionsWithDateText = (contributions, date) => {
+export const contributionsWithDate = (contributions, date) => {
   const contributionsWithDateText = document.createElement('SPAN');
 
   contributionsWithDateText.style.color = '#FFFFFF';
@@ -118,9 +118,9 @@ export const tooltipContributionsWithDateText = (contributions, date) => {
     contributionsWithDateText.innerText = `${contributions} contributions`;
   }
 
-  const contributionsDateText = getContributionsDateText(date);
+  const dateText = getDateText(date);
 
-  contributionsWithDateText.appendChild(contributionsDateText);
+  contributionsWithDateText.appendChild(dateText);
 
   return contributionsWithDateText;
 };

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
@@ -107,20 +107,20 @@ const getDateText = (date) => {
   return contributionsDateText;
 };
 
-export const contributionsWithDate = (contributions, date) => {
-  const contributionsWithDateText = document.createElement('SPAN');
+export const contributionsWithDateText = (contributions, date) => {
+  const tooltipText = document.createElement('SPAN');
 
-  contributionsWithDateText.style.color = '#FFFFFF';
-  contributionsWithDateText.style.fontWeight = 'bold';
-  contributionsWithDateText.innerText = 'No contributions';
+  tooltipText.style.color = '#FFFFFF';
+  tooltipText.style.fontWeight = 'bold';
+  tooltipText.innerText = 'No contributions';
 
   if (contributions > 0) {
-    contributionsWithDateText.innerText = `${contributions} contributions`;
+    tooltipText.innerText = `${contributions} contributions`;
   }
 
   const dateText = getDateText(date);
 
-  contributionsWithDateText.appendChild(dateText);
+  tooltipText.appendChild(dateText);
 
-  return contributionsWithDateText;
+  return tooltipText;
 };

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
@@ -98,13 +98,13 @@ export const tooltip = () => {
 };
 
 const getDateText = (date) => {
-  const contributionsDateText = document.createElement('SPAN');
+  const dateText = document.createElement('SPAN');
 
-  contributionsDateText.style.color = '#959DA5';
-  contributionsDateText.style.fontWeight = 'normal';
-  contributionsDateText.innerText = ` on ${date}`;
+  dateText.style.color = '#959DA5';
+  dateText.style.fontWeight = 'normal';
+  dateText.innerText = ` on ${date}`;
 
-  return contributionsDateText;
+  return dateText;
 };
 
 export const contributionsWithDateText = (contributions, date) => {

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
@@ -88,8 +88,6 @@ export const tooltip = () => {
   calendarTooltip.style.padding = '10px';
   calendarTooltip.style.textAlign = 'center';
   calendarTooltip.style.position = 'absolute';
-  calendarTooltip.style.zIndex = '99999';
-
   calendarTooltip.style.display = 'none';
   calendarTooltip.style.left = '0px';
   calendarTooltip.style.top = '0px';

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
@@ -76,3 +76,24 @@ export const header = (totalContributions, isLoading) => {
 
   return calendarHeader;
 };
+
+export const tooltip = () => {
+  const calendarTooltip = document.createElement('DIV');
+
+  calendarTooltip.id = 'tooltip';
+
+  calendarTooltip.style.background = 'rgba(0, 0, 0, 0.8)';
+  calendarTooltip.style.borderRadius = '3px';
+  calendarTooltip.style.color = '#959da5';
+  calendarTooltip.style.fontSize = '12px';
+  calendarTooltip.style.padding = '10px';
+  calendarTooltip.style.textAlign = 'center';
+  calendarTooltip.style.position = 'absolute';
+  calendarTooltip.style.zIndex = '99999';
+
+  calendarTooltip.style.display = 'none';
+  calendarTooltip.style.left = '0px';
+  calendarTooltip.style.top = '0px';
+
+  return calendarTooltip;
+};

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.js
@@ -84,7 +84,6 @@ export const tooltip = () => {
 
   calendarTooltip.style.background = 'rgba(0, 0, 0, 0.8)';
   calendarTooltip.style.borderRadius = '3px';
-  calendarTooltip.style.color = '#959da5';
   calendarTooltip.style.fontSize = '12px';
   calendarTooltip.style.padding = '10px';
   calendarTooltip.style.textAlign = 'center';
@@ -96,4 +95,32 @@ export const tooltip = () => {
   calendarTooltip.style.top = '0px';
 
   return calendarTooltip;
+};
+
+const getContributionsDateText = (date) => {
+  const contributionsDateText = document.createElement('SPAN');
+
+  contributionsDateText.style.color = '#959DA5';
+  contributionsDateText.style.fontWeight = 'normal';
+  contributionsDateText.innerText = ` on ${date}`;
+
+  return contributionsDateText;
+};
+
+export const tooltipContributionsWithDateText = (contributions, date) => {
+  const contributionsWithDateText = document.createElement('SPAN');
+
+  contributionsWithDateText.style.color = '#FFFFFF';
+  contributionsWithDateText.style.fontWeight = 'bold';
+  contributionsWithDateText.innerText = 'No contributions';
+
+  if (contributions > 0) {
+    contributionsWithDateText.innerText = `${contributions} contributions`;
+  }
+
+  const contributionsDateText = getContributionsDateText(date);
+
+  contributionsWithDateText.appendChild(contributionsDateText);
+
+  return contributionsWithDateText;
 };

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
@@ -81,11 +81,11 @@ describe('GetStyledCalendarElement', () => {
     });
   });
 
-  describe('contributionsWithDate', () => {
+  describe('contributionsWithDateText', () => {
     const date = '2019-01-23';
 
     it('returns a `span` element', () => {
-      const tooltipText = GetStyledCalendarElement.contributionsWithDate(
+      const tooltipText = GetStyledCalendarElement.contributionsWithDateText(
         50, date,
       );
 
@@ -93,7 +93,7 @@ describe('GetStyledCalendarElement', () => {
     });
 
     it('appends a `span` to the tooltip element', () => {
-      const tooltipText = GetStyledCalendarElement.contributionsWithDate(
+      const tooltipText = GetStyledCalendarElement.contributionsWithDateText(
         50, date,
       );
 
@@ -103,7 +103,7 @@ describe('GetStyledCalendarElement', () => {
     it('sets the appended span`s text to the given date', () => {
       const expectedDateText = ` on ${date}`;
 
-      const tooltipText = GetStyledCalendarElement.contributionsWithDate(
+      const tooltipText = GetStyledCalendarElement.contributionsWithDateText(
         50, date,
       );
 
@@ -118,7 +118,7 @@ describe('GetStyledCalendarElement', () => {
       it('renders `No contributions`', () => {
         const expectedContributionsText = 'No contributions';
 
-        const tooltipText = GetStyledCalendarElement.contributionsWithDate(
+        const tooltipText = GetStyledCalendarElement.contributionsWithDateText(
           contributions, date,
         );
 
@@ -134,7 +134,7 @@ describe('GetStyledCalendarElement', () => {
       it('renders the passed `contributions`', () => {
         const expectedContributionsText = `${contributions} contributions`;
 
-        const tooltipText = GetStyledCalendarElement.contributionsWithDate(
+        const tooltipText = GetStyledCalendarElement.contributionsWithDateText(
           contributions, date,
         );
 

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
@@ -131,7 +131,7 @@ describe('GetStyledCalendarElement', () => {
     describe('when the `contributions` is higher than 0', () => {
       const contributions = 1;
 
-      it('renders the passed `contributions`', () => {
+      it('renders the given `contributions`', () => {
         const expectedContributionsText = `${contributions} contributions`;
 
         const tooltipText = GetStyledCalendarElement.contributionsWithDateText(

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
@@ -81,34 +81,34 @@ describe('GetStyledCalendarElement', () => {
     });
   });
 
-  describe('tooltipContributionsWithDateText', () => {
+  describe('contributionsWithDate', () => {
     const date = '2019-01-23';
 
     it('returns a `span` element', () => {
-      const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+      const tooltipText = GetStyledCalendarElement.contributionsWithDate(
         50, date,
       );
 
-      expect(contributionsWithDateText.nodeName).to.equal('SPAN');
+      expect(tooltipText.nodeName).to.equal('SPAN');
     });
 
     it('appends a `span` to the tooltip element', () => {
-      const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+      const tooltipText = GetStyledCalendarElement.contributionsWithDate(
         50, date,
       );
 
-      expect(contributionsWithDateText.childNodes[0].nodeName).to.equal('SPAN');
+      expect(tooltipText.childNodes[0].nodeName).to.equal('SPAN');
     });
 
     it('sets the appended span`s text to the given date', () => {
-      const expectedContributionsDateText = ` on ${date}`;
+      const expectedDateText = ` on ${date}`;
 
-      const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+      const tooltipText = GetStyledCalendarElement.contributionsWithDate(
         50, date,
       );
 
-      expect(contributionsWithDateText.childNodes[0].innerText).to.equal(
-        expectedContributionsDateText,
+      expect(tooltipText.childNodes[0].innerText).to.equal(
+        expectedDateText,
       );
     });
 
@@ -118,11 +118,11 @@ describe('GetStyledCalendarElement', () => {
       it('renders `No contributions`', () => {
         const expectedContributionsText = 'No contributions';
 
-        const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+        const tooltipText = GetStyledCalendarElement.contributionsWithDate(
           contributions, date,
         );
 
-        expect(contributionsWithDateText.innerText).to.equal(
+        expect(tooltipText.innerText).to.equal(
           expectedContributionsText,
         );
       });
@@ -134,11 +134,11 @@ describe('GetStyledCalendarElement', () => {
       it('renders the passed `contributions`', () => {
         const expectedContributionsText = `${contributions} contributions`;
 
-        const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+        const tooltipText = GetStyledCalendarElement.contributionsWithDate(
           contributions, date,
         );
 
-        expect(contributionsWithDateText.innerText).to.equal(
+        expect(tooltipText.innerText).to.equal(
           expectedContributionsText,
         );
       });

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
@@ -80,4 +80,68 @@ describe('GetStyledCalendarElement', () => {
       expect(calendarTooltip.nodeName).to.equal('DIV');
     });
   });
+
+  describe('tooltipContributionsWithDateText', () => {
+    const date = '2019-01-23';
+
+    it('returns a `span` element', () => {
+      const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+        50, date,
+      );
+
+      expect(contributionsWithDateText.nodeName).to.equal('SPAN');
+    });
+
+    it('appends a `span` to the text', () => {
+      const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+        50, date,
+      );
+
+      expect(contributionsWithDateText.childNodes[0].nodeName).to.equal('SPAN');
+    });
+
+    it('sets the appended span`s text to the given date', () => {
+      const expectedContributionsDateText = ` on ${date}`;
+
+      const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+        50, date,
+      );
+
+      expect(contributionsWithDateText.childNodes[0].innerText).to.equal(
+        expectedContributionsDateText,
+      );
+    });
+
+    describe('when the `contributions` is 0', () => {
+      const contributions = 0;
+
+      it('renders the `No contributions` text', () => {
+        const expectedContributionsText = 'No contributions';
+
+        const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+          contributions, date,
+        );
+
+        expect(contributionsWithDateText.innerText).to.equal(
+          expectedContributionsText,
+        );
+      });
+    });
+
+    describe('when the `contributions` is higher than 0', () => {
+      const contributions = 1;
+
+      it('renders the `contributions` text', () => {
+        const expectedContributionsText = `${contributions} contributions`;
+
+        const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+          contributions, date,
+        );
+
+        expect(contributionsWithDateText.innerText).to.equal(
+          expectedContributionsText,
+        );
+      });
+    });
+  });
 });

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
@@ -92,7 +92,7 @@ describe('GetStyledCalendarElement', () => {
       expect(contributionsWithDateText.nodeName).to.equal('SPAN');
     });
 
-    it('appends a `span` to the text', () => {
+    it('appends a `span` to the tooltip element', () => {
       const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
         50, date,
       );
@@ -115,7 +115,7 @@ describe('GetStyledCalendarElement', () => {
     describe('when the `contributions` is 0', () => {
       const contributions = 0;
 
-      it('renders the `No contributions` text', () => {
+      it('renders `No contributions`', () => {
         const expectedContributionsText = 'No contributions';
 
         const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
@@ -131,7 +131,7 @@ describe('GetStyledCalendarElement', () => {
     describe('when the `contributions` is higher than 0', () => {
       const contributions = 1;
 
-      it('renders the `contributions` text', () => {
+      it('renders the passed `contributions`', () => {
         const expectedContributionsText = `${contributions} contributions`;
 
         const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
@@ -66,4 +66,18 @@ describe('GetStyledCalendarElement', () => {
       expect(calendarHeader.childNodes[1].nodeName).to.equal('UL');
     });
   });
+
+  describe('tooltip', () => {
+    it('sets the `id` attribute to `tooltip`', () => {
+      const calendarTooltip = GetStyledCalendarElement.tooltip();
+
+      expect(calendarTooltip.id).to.equal('tooltip');
+    });
+
+    it('returns a `div` element', () => {
+      const calendarTooltip = GetStyledCalendarElement.tooltip();
+
+      expect(calendarTooltip.nodeName).to.equal('DIV');
+    });
+  });
 });

--- a/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
+++ b/src/utils/GetStyledCalendarElement/GetStyledCalendarElement.test.js
@@ -85,29 +85,29 @@ describe('GetStyledCalendarElement', () => {
     const date = '2019-01-23';
 
     it('returns a `span` element', () => {
-      const tooltipText = GetStyledCalendarElement.contributionsWithDateText(
+      const tooltipInnerText = GetStyledCalendarElement.contributionsWithDateText(
         50, date,
       );
 
-      expect(tooltipText.nodeName).to.equal('SPAN');
+      expect(tooltipInnerText.nodeName).to.equal('SPAN');
     });
 
     it('appends a `span` to the tooltip element', () => {
-      const tooltipText = GetStyledCalendarElement.contributionsWithDateText(
+      const tooltipInnerText = GetStyledCalendarElement.contributionsWithDateText(
         50, date,
       );
 
-      expect(tooltipText.childNodes[0].nodeName).to.equal('SPAN');
+      expect(tooltipInnerText.childNodes[0].nodeName).to.equal('SPAN');
     });
 
     it('sets the appended span`s text to the given date', () => {
       const expectedDateText = ` on ${date}`;
 
-      const tooltipText = GetStyledCalendarElement.contributionsWithDateText(
+      const tooltipInnerText = GetStyledCalendarElement.contributionsWithDateText(
         50, date,
       );
 
-      expect(tooltipText.childNodes[0].innerText).to.equal(
+      expect(tooltipInnerText.childNodes[0].innerText).to.equal(
         expectedDateText,
       );
     });
@@ -118,11 +118,11 @@ describe('GetStyledCalendarElement', () => {
       it('renders `No contributions`', () => {
         const expectedContributionsText = 'No contributions';
 
-        const tooltipText = GetStyledCalendarElement.contributionsWithDateText(
+        const tooltipInnerText = GetStyledCalendarElement.contributionsWithDateText(
           contributions, date,
         );
 
-        expect(tooltipText.innerText).to.equal(
+        expect(tooltipInnerText.innerText).to.equal(
           expectedContributionsText,
         );
       });

--- a/src/utils/Tooltip/Tooltip.js
+++ b/src/utils/Tooltip/Tooltip.js
@@ -9,11 +9,11 @@ const showTooltip = (event) => {
 
   const tooltipDOMElement = document.getElementById('tooltip');
 
-  const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+  const tooltipText = GetStyledCalendarElement.contributionsWithDate(
     contributions, date,
   );
 
-  tooltipDOMElement.appendChild(contributionsWithDateText);
+  tooltipDOMElement.appendChild(tooltipText);
 
   tooltipDOMElement.style.display = 'block';
   tooltipDOMElement.style.top = `${rectCoordinates.top - 40}px`;

--- a/src/utils/Tooltip/Tooltip.js
+++ b/src/utils/Tooltip/Tooltip.js
@@ -1,6 +1,6 @@
 import * as GetStyledCalendarElement from '../GetStyledCalendarElement/GetStyledCalendarElement';
 
-const showContributionsTooltip = (event) => {
+const showTooltip = (event) => {
   const hoveredRectElement = event.target;
 
   const contributions = Number(hoveredRectElement.getAttribute('data-count'));
@@ -14,12 +14,13 @@ const showContributionsTooltip = (event) => {
   );
 
   tooltipDOMElement.appendChild(contributionsWithDateText);
+
   tooltipDOMElement.style.display = 'block';
   tooltipDOMElement.style.top = `${rectCoordinates.top - 40}px`;
   tooltipDOMElement.style.left = `${rectCoordinates.left - (tooltipDOMElement.clientWidth / 2)}px`;
 };
 
-const hideContributionsTooltip = () => {
+const hideTooltip = () => {
   const tooltipDOMElement = document.getElementById('tooltip');
 
   if (tooltipDOMElement.childNodes.length === 0) {
@@ -38,7 +39,7 @@ export const addEvents = () => {
   const rects = Array.from(rectElements);
 
   rects.forEach((rect) => {
-    rect.addEventListener('mouseenter', showContributionsTooltip);
-    rect.addEventListener('mouseleave', hideContributionsTooltip);
+    rect.addEventListener('mouseenter', showTooltip);
+    rect.addEventListener('mouseleave', hideTooltip);
   });
 };

--- a/src/utils/Tooltip/Tooltip.js
+++ b/src/utils/Tooltip/Tooltip.js
@@ -35,7 +35,7 @@ const hideTooltip = () => {
   tooltipDOMElement.removeChild(tooltipDOMElement.childNodes[0]);
 };
 
-export const addEvents = () => {
+export const addEventsToRectElements = () => {
   const rectElements = document.getElementsByTagName('rect');
   const rects = Array.from(rectElements);
 

--- a/src/utils/Tooltip/Tooltip.js
+++ b/src/utils/Tooltip/Tooltip.js
@@ -1,26 +1,24 @@
 import * as GetStyledCalendarElement from '../GetStyledCalendarElement/GetStyledCalendarElement';
 
 const showTooltip = (event) => {
-  const hoveredRectElement = event.target;
+  const hoveredDay = event.target;
 
-  const contributions = Number(hoveredRectElement.getAttribute('data-count'));
-  const date = hoveredRectElement.getAttribute('data-date');
-  const rectCoordinates = hoveredRectElement.getBoundingClientRect();
+  const contributions = Number(hoveredDay.getAttribute('data-count'));
+  const date = hoveredDay.getAttribute('data-date');
 
-  const tooltipDOMElement = document.getElementById('tooltip');
+  const tooltipElement = document.getElementById('tooltip');
 
-  const tooltipText = GetStyledCalendarElement.contributionsWithDateText(
+  const tooltipInnerText = GetStyledCalendarElement.contributionsWithDateText(
     contributions, date,
   );
 
-  tooltipDOMElement.appendChild(tooltipText);
+  tooltipElement.appendChild(tooltipInnerText);
 
-  const toopltipTopPosition = `${rectCoordinates.top - 40}px`;
-  const tooltipLeftPosition = `${rectCoordinates.left - (tooltipDOMElement.clientWidth / 2)}px`;
+  const hoveredDayPositionAttributes = hoveredDay.getBoundingClientRect();
 
-  tooltipDOMElement.style.display = 'block';
-  tooltipDOMElement.style.top = toopltipTopPosition;
-  tooltipDOMElement.style.left = tooltipLeftPosition;
+  tooltipElement.style.display = 'block';
+  tooltipElement.style.top = `${hoveredDayPositionAttributes.top - 35}px`;
+  tooltipElement.style.left = `${hoveredDayPositionAttributes.left - (tooltipElement.clientWidth / 2)}px`;
 };
 
 const hideTooltip = () => {

--- a/src/utils/Tooltip/Tooltip.js
+++ b/src/utils/Tooltip/Tooltip.js
@@ -9,7 +9,7 @@ const showTooltip = (event) => {
 
   const tooltipDOMElement = document.getElementById('tooltip');
 
-  const tooltipText = GetStyledCalendarElement.contributionsWithDate(
+  const tooltipText = GetStyledCalendarElement.contributionsWithDateText(
     contributions, date,
   );
 

--- a/src/utils/Tooltip/Tooltip.js
+++ b/src/utils/Tooltip/Tooltip.js
@@ -22,17 +22,17 @@ const showTooltip = (event) => {
 };
 
 const hideTooltip = () => {
-  const tooltipDOMElement = document.getElementById('tooltip');
+  const tooltipElement = document.getElementById('tooltip');
 
-  if (tooltipDOMElement.childNodes.length === 0) {
+  if (tooltipElement.childNodes.length === 0) {
     return;
   }
 
-  tooltipDOMElement.style.display = 'none';
-  tooltipDOMElement.style.top = '0px';
-  tooltipDOMElement.style.left = '0px;';
+  tooltipElement.style.display = 'none';
+  tooltipElement.style.top = '0px';
+  tooltipElement.style.left = '0px;';
 
-  tooltipDOMElement.removeChild(tooltipDOMElement.childNodes[0]);
+  tooltipElement.removeChild(tooltipElement.childNodes[0]);
 };
 
 export const addEventsToRectElements = () => {

--- a/src/utils/Tooltip/Tooltip.js
+++ b/src/utils/Tooltip/Tooltip.js
@@ -37,9 +37,9 @@ const hideTooltip = () => {
 
 export const addEventsToRectElements = () => {
   const rectElements = document.getElementsByTagName('rect');
-  const rects = Array.from(rectElements);
+  const rectsArray = Array.from(rectElements);
 
-  rects.forEach((rect) => {
+  rectsArray.forEach((rect) => {
     rect.addEventListener('mouseenter', showTooltip);
     rect.addEventListener('mouseleave', hideTooltip);
   });

--- a/src/utils/Tooltip/Tooltip.js
+++ b/src/utils/Tooltip/Tooltip.js
@@ -1,0 +1,44 @@
+import * as GetStyledCalendarElement from '../GetStyledCalendarElement/GetStyledCalendarElement';
+
+const showContributionsTooltip = (event) => {
+  const hoveredRectElement = event.target;
+
+  const contributions = Number(hoveredRectElement.getAttribute('data-count'));
+  const date = hoveredRectElement.getAttribute('data-date');
+  const rectCoordinates = hoveredRectElement.getBoundingClientRect();
+
+  const tooltipDOMElement = document.getElementById('tooltip');
+
+  const contributionsWithDateText = GetStyledCalendarElement.tooltipContributionsWithDateText(
+    contributions, date,
+  );
+
+  tooltipDOMElement.appendChild(contributionsWithDateText);
+  tooltipDOMElement.style.display = 'block';
+  tooltipDOMElement.style.top = `${rectCoordinates.top - 40}px`;
+  tooltipDOMElement.style.left = `${rectCoordinates.left - (tooltipDOMElement.clientWidth / 2)}px`;
+};
+
+const hideContributionsTooltip = () => {
+  const tooltipDOMElement = document.getElementById('tooltip');
+
+  if (tooltipDOMElement.childNodes.length === 0) {
+    return;
+  }
+
+  tooltipDOMElement.style.display = 'none';
+  tooltipDOMElement.style.top = '0px';
+  tooltipDOMElement.style.left = '0px;';
+
+  tooltipDOMElement.removeChild(tooltipDOMElement.childNodes[0]);
+};
+
+export const addEvents = () => {
+  const rectElements = document.getElementsByTagName('rect');
+  const rects = Array.from(rectElements);
+
+  rects.forEach((rect) => {
+    rect.addEventListener('mouseenter', showContributionsTooltip);
+    rect.addEventListener('mouseleave', hideContributionsTooltip);
+  });
+};

--- a/src/utils/Tooltip/Tooltip.js
+++ b/src/utils/Tooltip/Tooltip.js
@@ -15,9 +15,12 @@ const showTooltip = (event) => {
 
   tooltipDOMElement.appendChild(tooltipText);
 
+  const toopltipTopPosition = `${rectCoordinates.top - 40}px`;
+  const tooltipLeftPosition = `${rectCoordinates.left - (tooltipDOMElement.clientWidth / 2)}px`;
+
   tooltipDOMElement.style.display = 'block';
-  tooltipDOMElement.style.top = `${rectCoordinates.top - 40}px`;
-  tooltipDOMElement.style.left = `${rectCoordinates.left - (tooltipDOMElement.clientWidth / 2)}px`;
+  tooltipDOMElement.style.top = toopltipTopPosition;
+  tooltipDOMElement.style.left = tooltipLeftPosition;
 };
 
 const hideTooltip = () => {


### PR DESCRIPTION
Issue #18.

Changes:
- applied @bencefrelli 's flow to the current structure,
- refactored, separated the tooltip related stuff into a single folder,
- extended `GetStyledCalendarElement` with other "generators"(+tests).

Is it possible to test the functions in `Tooltip.js`? I suspect that the correct answer is no because:
- they don't return any value,
- most of the calls are built-in ones.

An additional, slight reason would be that the `showTooltip` and `hideTooltip` functions aren't being exposed.

Unfortunately, the cursor can't be seen on the GIF, but feel free to try the functionality out locally.

![pr_23_preview](https://user-images.githubusercontent.com/30864202/56467550-aadf4200-6420-11e9-9870-6741ff9f0eaa.gif)

