### PR TITLE
create dev script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # npm package lock
 /package-lock.json
+
+# parcel
+.cache/
+/dist

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@
 
 # parcel
 .cache/
-/dist

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # parcel
 .cache/
+/dev/parcel

--- a/dev/index.html
+++ b/dev/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+  <head>
+    <script src="../src/index.js"></script>
+  </head>
+
+  <body>
+    <div class="container" />
+
+    <script>
+      TeamContributionCalendar.default(".container", ["nkapolcs"])
+    </script>
+  </body>
+</html>

--- a/dev/index.html
+++ b/dev/index.html
@@ -7,7 +7,7 @@
     <div class="container" />
 
     <script>
-      TeamContributionCalendar.default(".container", ["nkapolcs"])
+      TeamContributionCalendar.default(".container", ["tccemptyuser"])
     </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "GitHub-like contribution calendar for the whole team. Supports GitHub and GitLab.",
   "main": "./lib/index.js",
   "scripts": {
-    "dev": "parcel ./dev/index.html --global TeamContributionCalendar",
+    "dev": "parcel ./dev/index.html --global TeamContributionCalendar -d ./lib/",
     "build": "cross-env BABEL_ENV=production babel src --out-dir lib --copy-files",
     "clean:lib": "rimraf lib",
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "GitHub-like contribution calendar for the whole team. Supports GitHub and GitLab.",
   "main": "./lib/index.js",
   "scripts": {
-    "dev": "parcel ./dev/index.html --global TeamContributionCalendar -d ./lib/",
+    "dev": "parcel ./dev/index.html --global TeamContributionCalendar -d ./dev/parcel",
     "build": "cross-env BABEL_ENV=production babel src --out-dir lib --copy-files",
     "clean:lib": "rimraf lib",
     "lint": "eslint src",

--- a/package.json
+++ b/package.json
@@ -68,13 +68,9 @@
   },
   "browserslist": [
     "last 2 Chrome versions",
-    "last 2 ChromeAndroid versions",
     "last 2 Firefox versions",
-    "last 2 FirefoxAndroid versions",
     "last 2 Safari versions",
-    "last 2 iOS versions",
     "last 2 Edge versions",
-    "last 2 Opera versions",
-    "last 2 OperaMobile versions"
+    "last 2 Opera versions"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "GitHub-like contribution calendar for the whole team. Supports GitHub and GitLab.",
   "main": "./lib/index.js",
   "scripts": {
+    "dev": "parcel ./dev/index.html --global TeamContributionCalendar",
     "build": "cross-env BABEL_ENV=production babel src --out-dir lib --copy-files",
     "clean:lib": "rimraf lib",
     "lint": "eslint src",
@@ -24,6 +25,7 @@
   },
   "homepage": "https://github.com/c-hive/team-contribution-calendar#readme",
   "devDependencies": {
+    "parcel-bundler": "^1.12.3",
     "@babel/cli": "^7.4.3",
     "@babel/core": "^7.4.3",
     "@babel/plugin-transform-runtime": "^7.4.3",
@@ -63,5 +65,16 @@
   "dependencies": {
     "elly": "^1.1.10",
     "svgson": "^3.1.0"
-  }
+  },
+  "browserslist": [
+    "last 2 Chrome versions",
+    "last 2 ChromeAndroid versions",
+    "last 2 Firefox versions",
+    "last 2 FirefoxAndroid versions",
+    "last 2 Safari versions",
+    "last 2 iOS versions",
+    "last 2 Edge versions",
+    "last 2 Opera versions",
+    "last 2 OperaMobile versions"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/c-hive/team-contribution-calendar#readme",
   "devDependencies": {
     "parcel-bundler": "^1.12.3",
+    "parcel-plugin-inlinesvg": "^0.1.1",
     "@babel/cli": "^7.4.3",
     "@babel/core": "^7.4.3",
     "@babel/plugin-transform-runtime": "^7.4.3",


### PR DESCRIPTION
Issue #43.

Add a script (and possibly some code) so that when running npm run dev a local instance of TCC is served from source

Changes:
- [x] create `npm run dev` with parcel to create development workflow
- [x] change .gitignore
- [x] support static svg
