### PR TITLE
Improve Travis YAML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ stages:
     - test
     - name: distify
       if: branch = master
-    - release
+    - name: release
+      if: tag =~ /^v[0-9]\.[0-9]\.[0-9]$/
 jobs:
   include:
     - stage: lint
@@ -30,6 +31,5 @@ jobs:
         api_key: $NPM_TOKEN
         on:
           all_branches: true
-          condition: $TRAVIS_TAG =~ /^v[0-9]\.[0-9]\.[0-9]$/
 after_success:
   - yarn run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ stages:
     - test
     - name: distify
       if: branch = master
-    - name: release
-      if: tag =~ /^v[0-9]\.[0-9]\.[0-9]$/
+    - release
 jobs:
   include:
     - stage: lint
@@ -29,5 +28,8 @@ jobs:
       deploy:
         provider: npm
         api_key: $NPM_TOKEN
+        on:
+          all_branches: true
+          condition: $TRAVIS_TAG =~ /^v[0-9]\.[0-9]\.[0-9]$/
 after_success:
   - yarn run coveralls


### PR DESCRIPTION
There's no relevant issue.

Travis skips releasing to npm due to permission issues(it's also indicated by the thrown error message):
- `Skipping a deployment with the npm provider because this branch is not permitted: v0.1.1`

It seems the common use-case is to set `all_branches` to `true`:
- https://stackoverflow.com/a/27775257/9599137
- https://stackoverflow.com/a/43129514/9599137

Hopefully this will fix our release flow.
