### PR TITLE
Issue 40 Support for timeframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,14 @@ We recommend using `yarn` because of [compatibility](https://github.com/c-hive/t
 </pre>
 
 - `container`: a DOM element in which the calendar will be rendered
-- `gitHubUsers` / `gitLabUsers`: array of user names  
-(optional: you can give timeframe to a user for example: `["tenderlove", ['2020-01-01','2020-03-01']]`)
+- `gitHubUsers` / `gitLabUsers`: array of users
+  - both of them should be defined even if they're empty
+  - optionally specify the starting point of the timeframe
+  - accepted formats
+    - `["tenderlove"]`
+    - `
+    - `[{ name: "tenderlove", from: "2020-01-01" }]`
+  - (optional: you can give timeframe to a user for example: `["tenderlove", ['2020-01-01','2020-03-01']]`)
 - `proxyServerUrl`: CORS proxy url
   - We serve one by default for _development purposes only_, no uptime guaranteed. Consider using your [own server](https://github.com/c-hive/cors-proxy). Keep it in mind, **otherwise you will most likely get 403 on production**.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ TeamContributionCalendar(container, ghUsernames, glUsernames, "https://your-prox
 <div class="container"></div>
 <script>
   const ghUsernames = [{ name: "gaearon" }, { name: "tenderlove", from: "2020-01-20" }, { name: "thisismydesign", from: "2020-01-20", to: "2020-03-20" }];
-  const glUsernames = [{ name: "gnachman" }, { name: "sytses", from: "2020-01-20" }];
+  const glUsernames = [{ name: "gnachman" }, { name: "sytses", from: "2020-01-20" }, { name: "gomorizsolt", to: "2020-04-03" }];
   TeamContributionCalendar(".container", ghUsernames, glUsernames, "https://your-proxy-server.com/");
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -36,23 +36,15 @@ We recommend using `yarn` because of [compatibility](https://github.com/c-hive/t
 </script>
 ```
 
-#### Config
+#### Configs
 
 <pre>
 <b>TeamContributionCalendar(container, gitHubUsers, gitLabUsers, proxyServerUrl)</b>
 </pre>
 
-- `container`: a DOM element in which the calendar will be rendered
-- `gitHubUsers` / `gitLabUsers`: array of users
-  - both of them should be defined even if they're empty
-  - optionally specify the starting point of the timeframe
-  - accepted formats
-    - `["tenderlove"]`
-    - `
-    - `[{ name: "tenderlove", from: "2020-01-01" }]`
-  - (optional: you can give timeframe to a user for example: `["tenderlove", ['2020-01-01','2020-03-01']]`)
-- `proxyServerUrl`: CORS proxy url
-  - We serve one by default for _development purposes only_, no uptime guaranteed. Consider using your [own server](https://github.com/c-hive/cors-proxy). Keep it in mind, **otherwise you will most likely get 403 on production**.
+Caveats:
+- The arrays representing the list of users currently support both strings and objects due to backward compatibility. It's strongly advised switching to the object format because strings will become deprecated in the future.
+- We serve a CORS proxy server by default but *for development purposes only*, no uptime guaranteed. Consider creating your [own server](https://github.com/c-hive/cors-proxy), **otherwise you will most likely get 403 on production**.
 
 #### Examples
 
@@ -62,8 +54,8 @@ We recommend using `yarn` because of [compatibility](https://github.com/c-hive/t
 import TeamContributionCalendar from "@c-hive/team-contribution-calendar";
 
 const container = document.getElementById("container");
-const ghUsernames = ["tenderlove", "gaearon"];
-const glUsernames = ["sytses", "gnachman"];
+const ghUsernames = ["tenderlove", { name: "gaearon" }];
+const glUsernames = [{ name: "sytses", from: "2020-01-20" }, "gnachman"];
 
 TeamContributionCalendar(container, ghUsernames, glUsernames, "https://your-proxy-server.com/");
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Status and support
 *You are viewing the README of version [v0.2.0](/../../releases/tag/v0.2.0). You can find other releases [here](/../../releases).*
 <!--- Version information end -->
 
- [![Build Status](https://github.com/c-hive/team-contribution-calendar/workflows/CI/badge.svg)](https://github.com/c-hive/team-contribution-calendar/actions)
+[![Build Status](https://github.com/c-hive/team-contribution-calendar/workflows/CI/badge.svg)](https://github.com/c-hive/team-contribution-calendar/actions)
 [![Coverage Status](https://coveralls.io/repos/github/c-hive/team-contribution-calendar/badge.svg?branch=master)](https://coveralls.io/github/c-hive/team-contribution-calendar?branch=master)
 [![npm version](https://badge.fury.io/js/%40c-hive%2Fteam-contribution-calendar.svg)](https://badge.fury.io/js/%40c-hive%2Fteam-contribution-calendar)
 [![Total Downloads](https://img.shields.io/npm/dw/@c-hive/team-contribution-calendar.svg)](https://www.npmjs.com/package/@c-hive/team-contribution-calendar)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ We recommend using `yarn` because of [compatibility](https://github.com/c-hive/t
 </pre>
 
 - `container`: a DOM element in which the calendar will be rendered
-- `gitHubUsers` / `gitLabUsers`: array of user names
+- `gitHubUsers` / `gitLabUsers`: array of user names  
+(optional: you can give timeframe to a user for example: `["tenderlove", ['2020-01-01','2020-03-01']]`)
 - `proxyServerUrl`: CORS proxy url
   - We serve one by default for _development purposes only_, no uptime guaranteed. Consider using your [own server](https://github.com/c-hive/cors-proxy). Keep it in mind, **otherwise you will most likely get 403 on production**.
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,9 @@ We recommend using `yarn` because of [compatibility](https://github.com/c-hive/t
 </script>
 ```
 
-#### Configs
-
-<pre>
-<b>TeamContributionCalendar(container, gitHubUsers, gitLabUsers, proxyServerUrl)</b>
-</pre>
-
-Caveats:
-- The arrays representing the list of users currently support both strings and objects due to backward compatibility. It's strongly advised switching to the object format because strings will become deprecated in the future.
-- We serve a CORS proxy server by default but *for development purposes only*, no uptime guaranteed. Consider creating your [own server](https://github.com/c-hive/cors-proxy), **otherwise you will most likely get 403 on production**.
-
 #### Examples
+
+Create your [CORS proxy server](https://github.com/Rob--W/cors-anywhere).
 
 ##### As dependency
 
@@ -54,8 +46,8 @@ Caveats:
 import TeamContributionCalendar from "@c-hive/team-contribution-calendar";
 
 const container = document.getElementById("container");
-const ghUsernames = ["tenderlove", { name: "gaearon" }];
-const glUsernames = [{ name: "sytses", from: "2020-01-20" }, "gnachman"];
+const ghUsernames = [{ name: "gaearon" }, { name: "tenderlove", from: "2020-01-20" }, { name: "thisismydesign", from: "2020-01-20", to: "2020-03-20" }];
+const glUsernames = [{ name: "gnachman" }, { name: "sytses", from: "2020-01-20" }];
 
 TeamContributionCalendar(container, ghUsernames, glUsernames, "https://your-proxy-server.com/");
 ```
@@ -65,17 +57,11 @@ TeamContributionCalendar(container, ghUsernames, glUsernames, "https://your-prox
 ```html
 <div class="container"></div>
 <script>
-   const ghUsernames = ["tenderlove", "gaearon"];
-   const glUsernames = ["sytses", "gnachman"];
-   TeamContributionCalendar(".container", ghUsernames, glUsernames, "https://your-proxy-server.com/");
+  const ghUsernames = [{ name: "gaearon" }, { name: "tenderlove", from: "2020-01-20" }, { name: "thisismydesign", from: "2020-01-20", to: "2020-03-20" }];
+  const glUsernames = [{ name: "gnachman" }, { name: "sytses", from: "2020-01-20" }];
+  TeamContributionCalendar(".container", ghUsernames, glUsernames, "https://your-proxy-server.com/");
 </script>
 ```
-
-## Contribution and feedback
-
-This project is built around known use-cases. If have one that isn't covered don't hesitate to open an issue and start a discussion.
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/c-hive/team-contribution-calendar. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## Conventions
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -7,7 +7,10 @@
     <div class="container" />
 
     <script>
-      TeamContributionCalendar.default(".container", ["tccemptyuser"])
+      TeamContributionCalendar.default(".container", 
+      [["gomorizsolt", ['2019-07-01','2019-08-04']]], 
+      [["nkapolcs", ['2019-09-01','2020-01-04']]], 
+      "https://zsgomori-cors-proxy.herokuapp.com/") 
     </script>
   </body>
 </html>

--- a/dev/index.html
+++ b/dev/index.html
@@ -8,7 +8,7 @@
 
     <script>
       TeamContributionCalendar.default(".container", 
-      [["gomorizsolt", ['2019-07-01','2019-08-04']]], 
+      [["gomorizsolt", ['2019-07-01','2019-08-04']], "tccemptyuser1"], 
       [["nkapolcs", ['2019-09-01','2020-01-04']]], 
       "https://zsgomori-cors-proxy.herokuapp.com/") 
     </script>

--- a/dev/index.html
+++ b/dev/index.html
@@ -8,7 +8,7 @@
 
     <script>
       TeamContributionCalendar.default(".container",
-      [{ name: "gomorizsolt", from: "2019-09-01" }, "thisismydesign"],
+      [{ name: "gomorizsolt", from: "2019-09-01", to: "2019-09-31" }, { name: "thisismydesign", from: "2020-02-01"}],
       [],
       "https://zsgomori-cors-proxy.herokuapp.com/")
     </script>

--- a/dev/index.html
+++ b/dev/index.html
@@ -7,10 +7,7 @@
     <div class="container" />
 
     <script>
-      TeamContributionCalendar.default(".container",
-      [{ name: "gomorizsolt", from: "2019-09-01", to: "2019-09-31" }, { name: "thisismydesign", from: "2020-02-01"}],
-      [],
-      "https://zsgomori-cors-proxy.herokuapp.com/")
+      TeamContributionCalendar.default(".container", ["tccemptyuser"])
     </script>
   </body>
 </html>

--- a/dev/index.html
+++ b/dev/index.html
@@ -7,10 +7,10 @@
     <div class="container" />
 
     <script>
-      TeamContributionCalendar.default(".container", 
-      [["gomorizsolt", ['2019-07-01','2019-08-04']], "tccemptyuser1"], 
-      [["nkapolcs", ['2019-09-01','2020-01-04']]], 
-      "https://zsgomori-cors-proxy.herokuapp.com/") 
+      TeamContributionCalendar.default(".container",
+      [{ name: "gomorizsolt", from: "2019-09-01" }, "thisismydesign"],
+      [],
+      "https://zsgomori-cors-proxy.herokuapp.com/")
     </script>
   </body>
 </html>

--- a/src/TeamContributionCalendar/TeamContributionCalendar.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.js
@@ -137,7 +137,10 @@ export default class TeamContributionCalendar {
       if (gitHubUserData.error) {
         console.error(gitHubUserData.errorMessage);
       } else {
-        this.processGitHubCalendar(gitHubUserData.parsedCalendar);
+        this.processGitHubCalendar(
+          gitHubUserData.parsedCalendar,
+          gitHubUserData.timeFrame
+        );
       }
     });
 
@@ -150,15 +153,19 @@ export default class TeamContributionCalendar {
       if (gitLabUserData.error) {
         console.error(gitLabUserData.errorMessage);
       } else {
-        this.processGitLabCalendar(gitLabUserData.parsedCalendar);
+        this.processGitLabCalendar(
+          gitLabUserData.parsedCalendar,
+          gitLabUserData.timeFrame
+        );
       }
     });
   }
 
-  processGitHubCalendar(gitHubUserJsonCalendar) {
+  processGitHubCalendar(gitHubUserJsonCalendar, gitHubUserTimeFrame) {
     const updatedSvg = gitHubUtils.mergeCalendarsContributions(
       this.actualSvg,
-      gitHubUserJsonCalendar
+      gitHubUserJsonCalendar,
+      gitHubUserTimeFrame
     );
 
     const lastYearContributions = gitHubUtils.getLastYearContributions(
@@ -175,10 +182,11 @@ export default class TeamContributionCalendar {
     });
   }
 
-  processGitLabCalendar(gitLabUserJsonCalendar) {
+  processGitLabCalendar(gitLabUserJsonCalendar, gitLabUserTimeFrame) {
     const updatedSvg = gitLabUtils.mergeCalendarsContributions(
       this.actualSvg,
-      gitLabUserJsonCalendar
+      gitLabUserJsonCalendar,
+      gitLabUserTimeFrame
     );
 
     const lastYearContributions = gitLabUtils.getLastYearContributions(

--- a/src/TeamContributionCalendar/TeamContributionCalendar.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.js
@@ -140,9 +140,7 @@ export default class TeamContributionCalendar {
       if (data.error) {
         console.error(data.errorMessage);
       } else {
-        const from = user.from || null;
-
-        this.processGitHubCalendar(data.parsedCalendar, from);
+        this.processGitHubCalendar(data.parsedCalendar, user.from);
       }
     });
 
@@ -158,9 +156,7 @@ export default class TeamContributionCalendar {
       if (data.error) {
         console.error(data.errorMessage);
       } else {
-        const from = user.from || null;
-
-        this.processGitLabCalendar(data.parsedCalendar, from);
+        this.processGitLabCalendar(data.parsedCalendar, user.from);
       }
     });
   }

--- a/src/TeamContributionCalendar/TeamContributionCalendar.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.js
@@ -128,44 +128,48 @@ export default class TeamContributionCalendar {
   }
 
   aggregateUserCalendars() {
-    this.users.gitHub.map(async gitHubUsername => {
-      const gitHubUserData = await gitHubUtils.getJsonFormattedCalendarAsync(
+    this.users.gitHub.map(async user => {
+      // This supports both the object and previous formats. It'll be deprecated sooner or later.
+      const username = user.name || user;
+
+      const data = await gitHubUtils.getJsonFormattedCalendarAsync(
         this.configs.proxyServerUrl,
-        gitHubUsername
+        username
       );
 
-      if (gitHubUserData.error) {
-        console.error(gitHubUserData.errorMessage);
+      if (data.error) {
+        console.error(data.errorMessage);
       } else {
-        this.processGitHubCalendar(
-          gitHubUserData.parsedCalendar,
-          gitHubUserData.timeFrame
-        );
+        const from = user.from || null;
+
+        this.processGitHubCalendar(data.parsedCalendar, from);
       }
     });
 
-    this.users.gitLab.map(async gitLabUsername => {
-      const gitLabUserData = await gitLabUtils.getJsonFormattedCalendarAsync(
+    this.users.gitLab.map(async user => {
+      // This supports both the object and previous formats. It'll be deprecated sooner or later.
+      const username = user.name || user;
+
+      const data = await gitLabUtils.getJsonFormattedCalendarAsync(
         this.configs.proxyServerUrl,
-        gitLabUsername
+        username
       );
 
-      if (gitLabUserData.error) {
-        console.error(gitLabUserData.errorMessage);
+      if (data.error) {
+        console.error(data.errorMessage);
       } else {
-        this.processGitLabCalendar(
-          gitLabUserData.parsedCalendar,
-          gitLabUserData.timeFrame
-        );
+        const from = user.from || null;
+
+        this.processGitLabCalendar(data.parsedCalendar, from);
       }
     });
   }
 
-  processGitHubCalendar(gitHubUserJsonCalendar, gitHubUserTimeFrame) {
+  processGitHubCalendar(gitHubUserJsonCalendar, from) {
     const updatedSvg = gitHubUtils.mergeCalendarsContributions(
       this.actualSvg,
       gitHubUserJsonCalendar,
-      gitHubUserTimeFrame
+      from
     );
 
     const lastYearContributions = gitHubUtils.getLastYearContributions(
@@ -182,11 +186,11 @@ export default class TeamContributionCalendar {
     });
   }
 
-  processGitLabCalendar(gitLabUserJsonCalendar, gitLabUserTimeFrame) {
+  processGitLabCalendar(gitLabUserJsonCalendar, from) {
     const updatedSvg = gitLabUtils.mergeCalendarsContributions(
       this.actualSvg,
       gitLabUserJsonCalendar,
-      gitLabUserTimeFrame
+      from
     );
 
     const lastYearContributions = gitLabUtils.getLastYearContributions(

--- a/src/TeamContributionCalendar/TeamContributionCalendar.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.js
@@ -140,7 +140,10 @@ export default class TeamContributionCalendar {
       if (data.error) {
         console.error(data.errorMessage);
       } else {
-        this.processGitHubCalendar(data.parsedCalendar, user.from);
+        this.processGitHubCalendar(data.parsedCalendar, {
+          start: user.from,
+          end: user.to
+        });
       }
     });
 
@@ -156,16 +159,19 @@ export default class TeamContributionCalendar {
       if (data.error) {
         console.error(data.errorMessage);
       } else {
-        this.processGitLabCalendar(data.parsedCalendar, user.from);
+        this.processGitLabCalendar(data.parsedCalendar, {
+          start: user.from,
+          end: user.to
+        });
       }
     });
   }
 
-  processGitHubCalendar(gitHubUserJsonCalendar, startDate) {
+  processGitHubCalendar(gitHubUserJsonCalendar, timeframe) {
     const updatedSvg = gitHubUtils.mergeCalendarsContributions(
       this.actualSvg,
       gitHubUserJsonCalendar,
-      startDate
+      timeframe
     );
 
     const lastYearContributions = gitHubUtils.getLastYearContributions(
@@ -182,11 +188,11 @@ export default class TeamContributionCalendar {
     });
   }
 
-  processGitLabCalendar(gitLabUserJsonCalendar, startDate) {
+  processGitLabCalendar(gitLabUserJsonCalendar, timeframe) {
     const updatedSvg = gitLabUtils.mergeCalendarsContributions(
       this.actualSvg,
       gitLabUserJsonCalendar,
-      startDate
+      timeframe
     );
 
     const lastYearContributions = gitLabUtils.getLastYearContributions(

--- a/src/TeamContributionCalendar/TeamContributionCalendar.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.js
@@ -161,11 +161,11 @@ export default class TeamContributionCalendar {
     });
   }
 
-  processGitHubCalendar(gitHubUserJsonCalendar, from) {
+  processGitHubCalendar(gitHubUserJsonCalendar, startDate) {
     const updatedSvg = gitHubUtils.mergeCalendarsContributions(
       this.actualSvg,
       gitHubUserJsonCalendar,
-      from
+      startDate
     );
 
     const lastYearContributions = gitHubUtils.getLastYearContributions(
@@ -182,11 +182,11 @@ export default class TeamContributionCalendar {
     });
   }
 
-  processGitLabCalendar(gitLabUserJsonCalendar, from) {
+  processGitLabCalendar(gitLabUserJsonCalendar, startDate) {
     const updatedSvg = gitLabUtils.mergeCalendarsContributions(
       this.actualSvg,
       gitLabUserJsonCalendar,
-      from
+      startDate
     );
 
     const lastYearContributions = gitLabUtils.getLastYearContributions(

--- a/src/TeamContributionCalendar/TeamContributionCalendar.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.js
@@ -129,7 +129,7 @@ export default class TeamContributionCalendar {
 
   aggregateUserCalendars() {
     this.users.gitHub.map(async user => {
-      // This supports both the object and previous formats. It'll be deprecated sooner or later.
+      // DEPRECATED: This supports both the object (current) and plain string (deprecated) formats.
       const username = user.name || user;
 
       const data = await gitHubUtils.getJsonFormattedCalendarAsync(
@@ -148,7 +148,7 @@ export default class TeamContributionCalendar {
     });
 
     this.users.gitLab.map(async user => {
-      // This supports both the object and previous formats. It'll be deprecated sooner or later.
+      // DEPRECATED: This supports both the object (current) and plain string (deprecated) formats.
       const username = user.name || user;
 
       const data = await gitLabUtils.getJsonFormattedCalendarAsync(

--- a/src/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -598,7 +598,8 @@ describe("TeamContributionCalendar", () => {
             "2019-03-20": 5
           }),
           error: false,
-          errorMessage: null
+          errorMessage: null,
+          timeFrame: null
         };
 
         beforeEach(() => {
@@ -610,7 +611,8 @@ describe("TeamContributionCalendar", () => {
 
           expect(
             processGitHubCalendarStub.calledWithExactly(
-              gitHubUserData.parsedCalendar
+              gitHubUserData.parsedCalendar,
+              gitHubUserData.timeFrame
             )
           ).to.equal(true);
         });
@@ -659,7 +661,8 @@ describe("TeamContributionCalendar", () => {
             "2018-02-09": 3
           },
           error: false,
-          errorMessage: null
+          errorMessage: null,
+          timeFrame: null
         };
 
         beforeEach(() => {
@@ -671,7 +674,8 @@ describe("TeamContributionCalendar", () => {
 
           expect(
             processGitLabCalendarStub.calledWithExactly(
-              gitLabUserData.parsedCalendar
+              gitLabUserData.parsedCalendar,
+              gitLabUserData.timeFrame
             )
           ).to.equal(true);
         });
@@ -697,6 +701,7 @@ describe("TeamContributionCalendar", () => {
       "2019-03-12": 7
     });
     const lastYearContributions = 1024;
+    const timeFrame = null;
 
     beforeEach(() => {
       mergeCalendarsContributionsStub = sandbox
@@ -717,12 +722,16 @@ describe("TeamContributionCalendar", () => {
     });
 
     it("merges the actual calendar contributions into the GH user`s contributions", () => {
-      teamContributionCalendar.processGitHubCalendar(gitHubUserJsonCalendar);
+      teamContributionCalendar.processGitHubCalendar(
+        gitHubUserJsonCalendar,
+        timeFrame
+      );
 
       expect(
         mergeCalendarsContributionsStub.calledWithExactly(
           teamContributionCalendar.actualSvg,
-          gitHubUserJsonCalendar
+          gitHubUserJsonCalendar,
+          timeFrame
         )
       ).to.equal(true);
     });
@@ -772,8 +781,8 @@ describe("TeamContributionCalendar", () => {
       "2018-02-03": 11,
       "2018-02-09": 20
     });
-
     const lastYearContributions = 2048;
+    const timeFrame = null;
 
     beforeEach(() => {
       mergeCalendarsContributionsStub = sandbox
@@ -794,18 +803,25 @@ describe("TeamContributionCalendar", () => {
     });
 
     it("merges the actual SVG contributions into the GL user`s contributions", () => {
-      teamContributionCalendar.processGitLabCalendar(gitLabUserJsonCalendar);
+      teamContributionCalendar.processGitLabCalendar(
+        gitLabUserJsonCalendar,
+        timeFrame
+      );
 
       expect(
         mergeCalendarsContributionsStub.calledWithExactly(
           teamContributionCalendar.actualSvg,
-          gitLabUserJsonCalendar
+          gitLabUserJsonCalendar,
+          timeFrame
         )
       ).to.equal(true);
     });
 
     it("calculates the user`s last year contributions", () => {
-      teamContributionCalendar.processGitLabCalendar(gitLabUserJsonCalendar);
+      teamContributionCalendar.processGitLabCalendar(
+        gitLabUserJsonCalendar,
+        timeFrame
+      );
 
       expect(
         getLastYearContributionsStub.calledWithExactly(gitLabUserJsonCalendar)

--- a/src/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -598,21 +598,23 @@ describe("TeamContributionCalendar", () => {
             "2019-03-20": 5
           }),
           error: false,
-          errorMessage: null,
-          startDate: "2019-09-01"
+          errorMessage: null
         };
 
         beforeEach(() => {
           gitHubGetJsonFormattedCalendarAsyncStub.returns(gitHubUserData);
         });
 
-        it("processes the fetched GH user calendars", async () => {
+        it("processes the user's calendar along with the specified timeframe", async () => {
           await teamContributionCalendar.aggregateUserCalendars();
 
           expect(
             processGitHubCalendarStub.calledWithExactly(
               gitHubUserData.parsedCalendar,
-              gitHubUserData.timeFrame
+              {
+                start: testParams.gitHubUsers[0].from,
+                end: testParams.gitHubUsers[0].end
+              }
             )
           ).to.equal(true);
         });
@@ -661,21 +663,23 @@ describe("TeamContributionCalendar", () => {
             "2018-02-09": 3
           },
           error: false,
-          errorMessage: null,
-          startDate: null
+          errorMessage: null
         };
 
         beforeEach(() => {
           gitLabGetJsonFormattedCalendarAsyncStub.returns(gitLabUserData);
         });
 
-        it("processes the fetched GL user calendars", async () => {
+        it("processes the user's calendar along with the specified timeframe", async () => {
           await teamContributionCalendar.aggregateUserCalendars();
 
           expect(
             processGitLabCalendarStub.calledWithExactly(
               gitLabUserData.parsedCalendar,
-              gitLabUserData.timeFrame
+              {
+                start: testParams.gitLabUsers[0].from,
+                end: testParams.gitLabUsers[0].end
+              }
             )
           ).to.equal(true);
         });

--- a/src/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -599,7 +599,7 @@ describe("TeamContributionCalendar", () => {
           }),
           error: false,
           errorMessage: null,
-          from: "2019-09-01"
+          startDate: "2019-09-01"
         };
 
         beforeEach(() => {
@@ -662,7 +662,7 @@ describe("TeamContributionCalendar", () => {
           },
           error: false,
           errorMessage: null,
-          from: null
+          startDate: null
         };
 
         beforeEach(() => {

--- a/src/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -599,7 +599,7 @@ describe("TeamContributionCalendar", () => {
           }),
           error: false,
           errorMessage: null,
-          timeFrame: null
+          from: "2019-09-01"
         };
 
         beforeEach(() => {
@@ -662,7 +662,7 @@ describe("TeamContributionCalendar", () => {
           },
           error: false,
           errorMessage: null,
-          timeFrame: null
+          from: null
         };
 
         beforeEach(() => {

--- a/src/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -705,7 +705,9 @@ describe("TeamContributionCalendar", () => {
       "2019-03-12": 7
     });
     const lastYearContributions = 1024;
-    const timeFrame = null;
+    const timeframe = {
+      start: "2020-01-31"
+    };
 
     beforeEach(() => {
       mergeCalendarsContributionsStub = sandbox
@@ -728,14 +730,14 @@ describe("TeamContributionCalendar", () => {
     it("merges the actual calendar contributions into the GH user`s contributions", () => {
       teamContributionCalendar.processGitHubCalendar(
         gitHubUserJsonCalendar,
-        timeFrame
+        timeframe
       );
 
       expect(
         mergeCalendarsContributionsStub.calledWithExactly(
           teamContributionCalendar.actualSvg,
           gitHubUserJsonCalendar,
-          timeFrame
+          timeframe
         )
       ).to.equal(true);
     });
@@ -786,7 +788,9 @@ describe("TeamContributionCalendar", () => {
       "2018-02-09": 20
     });
     const lastYearContributions = 2048;
-    const timeFrame = null;
+    const timeframe = {
+      end: "2019-02-05"
+    };
 
     beforeEach(() => {
       mergeCalendarsContributionsStub = sandbox
@@ -809,14 +813,14 @@ describe("TeamContributionCalendar", () => {
     it("merges the actual SVG contributions into the GL user`s contributions", () => {
       teamContributionCalendar.processGitLabCalendar(
         gitLabUserJsonCalendar,
-        timeFrame
+        timeframe
       );
 
       expect(
         mergeCalendarsContributionsStub.calledWithExactly(
           teamContributionCalendar.actualSvg,
           gitLabUserJsonCalendar,
-          timeFrame
+          timeframe
         )
       ).to.equal(true);
     });
@@ -824,7 +828,7 @@ describe("TeamContributionCalendar", () => {
     it("calculates the user`s last year contributions", () => {
       teamContributionCalendar.processGitLabCalendar(
         gitLabUserJsonCalendar,
-        timeFrame
+        timeframe
       );
 
       expect(

--- a/src/utils/CalendarUtils/CalendarUtils.js
+++ b/src/utils/CalendarUtils/CalendarUtils.js
@@ -53,15 +53,15 @@ export const elementExists = selector => {
 };
 
 export const filterContributionDays = (dailyData, startDate) => {
-  if (!startDate) {
-    return true;
-  }
-
   const isDay = dailyData.attributes.class === "day";
 
   // Weekdays and months displayed around the calendar should be disregarded.
   if (!isDay) {
     return false;
+  }
+
+  if (!startDate) {
+    return true;
   }
 
   const contributionsDate = new Date(dailyData.attributes["data-date"]);

--- a/src/utils/CalendarUtils/CalendarUtils.js
+++ b/src/utils/CalendarUtils/CalendarUtils.js
@@ -52,7 +52,11 @@ export const elementExists = selector => {
   return javaScriptUtils.isDefined(element);
 };
 
-export const filterContributionDays = (dailyData, from) => {
+export const filterContributionDays = (dailyData, startDate) => {
+  if (!startDate) {
+    return true;
+  }
+
   const isDay = dailyData.attributes.class === "day";
 
   // Weekdays and months displayed around the calendar should be disregarded.
@@ -60,11 +64,7 @@ export const filterContributionDays = (dailyData, from) => {
     return false;
   }
 
-  if (!from) {
-    return true;
-  }
+  const contributionsDate = new Date(dailyData.attributes["data-date"]);
 
-  const date = new Date(dailyData.attributes["data-date"]);
-
-  return date >= new Date(from);
+  return contributionsDate >= new Date(startDate);
 };

--- a/src/utils/CalendarUtils/CalendarUtils.js
+++ b/src/utils/CalendarUtils/CalendarUtils.js
@@ -51,3 +51,20 @@ export const elementExists = selector => {
 
   return javaScriptUtils.isDefined(element);
 };
+
+export const filterContributionDays = (dailyData, from) => {
+  const isDay = dailyData.attributes.class === "day";
+
+  // Weekdays and months displayed around the calendar should be disregarded.
+  if (!isDay) {
+    return false;
+  }
+
+  if (!from) {
+    return true;
+  }
+
+  const date = new Date(dailyData.attributes["data-date"]);
+
+  return date >= new Date(from);
+};

--- a/src/utils/CalendarUtils/CalendarUtils.js
+++ b/src/utils/CalendarUtils/CalendarUtils.js
@@ -52,7 +52,7 @@ export const elementExists = selector => {
   return javaScriptUtils.isDefined(element);
 };
 
-export const filterContributionDays = (dailyData, startDate) => {
+export const filterContributionDays = (dailyData, timeframe) => {
   const isDay = dailyData.attributes.class === "day";
 
   // Weekdays and months displayed around the calendar should be disregarded.
@@ -60,11 +60,22 @@ export const filterContributionDays = (dailyData, startDate) => {
     return false;
   }
 
-  if (!startDate) {
+  if (!timeframe.start && !timeframe.end) {
     return true;
   }
 
   const contributionsDate = new Date(dailyData.attributes["data-date"]);
 
-  return contributionsDate >= new Date(startDate);
+  if (timeframe.start && !timeframe.end) {
+    return contributionsDate >= new Date(timeframe.start);
+  }
+
+  if (!timeframe.start && timeframe.end) {
+    return contributionsDate <= new Date(timeframe.end);
+  }
+
+  return (
+    contributionsDate >= new Date(timeframe.start) &&
+    contributionsDate <= new Date(timeframe.end)
+  );
 };

--- a/src/utils/CalendarUtils/CalendarUtils.test.js
+++ b/src/utils/CalendarUtils/CalendarUtils.test.js
@@ -239,33 +239,36 @@ describe("CalendarUtils", () => {
     });
 
     describe("when the passed daily data is in fact a day", () => {
-      describe("when the starting point of the timeframe is not explicitly defined", () => {
+      describe("when the starting end ending points of the timeframe are not specified", () => {
         const dailyData = {
           attributes: {
             class: "day"
           }
         };
+        const timeframe = {};
 
         it("returns true", () => {
-          expect(calendarUtils.filterContributionDays(dailyData)).to.equal(
-            true
-          );
+          expect(
+            calendarUtils.filterContributionDays(dailyData, timeframe)
+          ).to.equal(true);
         });
       });
 
-      describe("when the starting point of the timeframe is explicitly defined", () => {
-        describe("when the contribution's date is earlier than starting point", () => {
+      describe("when the starting point of the timeframe is specified but the end date is missing", () => {
+        describe("when the contribution's date is earlier than the starting point", () => {
           const dailyData = {
             attributes: {
               class: "day",
               "data-date": "2019-09-01"
             }
           };
-          const startDate = "2019-09-02";
+          const timeframe = {
+            start: "2019-09-02"
+          };
 
           it("returns false", () => {
             expect(
-              calendarUtils.filterContributionDays(dailyData, startDate)
+              calendarUtils.filterContributionDays(dailyData, timeframe)
             ).to.equal(false);
           });
         });
@@ -274,15 +277,95 @@ describe("CalendarUtils", () => {
           const dailyData = {
             attributes: {
               class: "day",
-              "data-date": "2020-03-18"
+              "data-date": "2019-09-02"
             }
           };
-          const startDate = "2020-03-17";
+          const timeframe = {
+            start: "2019-09-01"
+          };
 
           it("returns true", () => {
             expect(
-              calendarUtils.filterContributionDays(dailyData, startDate)
+              calendarUtils.filterContributionDays(dailyData, timeframe)
             ).to.equal(true);
+          });
+        });
+      });
+
+      describe("when the end date of the timeframe is specified but the start date is missing", () => {
+        describe("when the contribution's date is not earlier than the end date", () => {
+          const dailyData = {
+            attributes: {
+              class: "day",
+              "data-date": "2019-09-03"
+            }
+          };
+          const timeframe = {
+            end: "2019-09-02"
+          };
+
+          it("returns false", () => {
+            expect(
+              calendarUtils.filterContributionDays(dailyData, timeframe)
+            ).to.equal(false);
+          });
+        });
+
+        describe("when the contribution's date is earlier than the end date", () => {
+          const dailyData = {
+            attributes: {
+              class: "day",
+              "data-date": "2019-09-02"
+            }
+          };
+          const timeframe = {
+            end: "2019-09-03"
+          };
+
+          it("returns true", () => {
+            expect(
+              calendarUtils.filterContributionDays(dailyData, timeframe)
+            ).to.equal(true);
+          });
+        });
+      });
+
+      describe("when the start and end dates of the timeframe are specified", () => {
+        describe("when the contribution's date falls into the timeframe", () => {
+          const dailyData = {
+            attributes: {
+              class: "day",
+              "data-date": "2019-09-02"
+            }
+          };
+          const timeframe = {
+            start: "2019-09-01",
+            end: "2019-09-03"
+          };
+
+          it("returns true", () => {
+            expect(
+              calendarUtils.filterContributionDays(dailyData, timeframe)
+            ).to.equal(true);
+          });
+        });
+
+        describe("when the contribution's date does not fall into the timeframe", () => {
+          const dailyData = {
+            attributes: {
+              class: "day",
+              "data-date": "2019-09-04"
+            }
+          };
+          const timeframe = {
+            start: "2019-09-01",
+            end: "2019-09-03"
+          };
+
+          it("returns false", () => {
+            expect(
+              calendarUtils.filterContributionDays(dailyData, timeframe)
+            ).to.equal(false);
           });
         });
       });

--- a/src/utils/CalendarUtils/CalendarUtils.test.js
+++ b/src/utils/CalendarUtils/CalendarUtils.test.js
@@ -224,4 +224,68 @@ describe("CalendarUtils", () => {
       });
     });
   });
+
+  describe("filterContributionDays", () => {
+    describe("when the passed daily data is either a month's or weekday's name", () => {
+      const dailyData = {
+        attributes: {
+          class: "month"
+        }
+      };
+
+      it("returns false", () => {
+        expect(calendarUtils.filterContributionDays(dailyData)).to.equal(false);
+      });
+    });
+
+    describe("when the passed daily data is in fact a day", () => {
+      describe("when the starting point of the timeframe is not explicitly defined", () => {
+        const dailyData = {
+          attributes: {
+            class: "day"
+          }
+        };
+
+        it("returns true", () => {
+          expect(calendarUtils.filterContributionDays(dailyData)).to.equal(
+            true
+          );
+        });
+      });
+
+      describe("when the starting point of the timeframe is explicitly defined", () => {
+        describe("when the contribution's date is earlier than starting point", () => {
+          const dailyData = {
+            attributes: {
+              class: "day",
+              "data-date": "2019-09-01"
+            }
+          };
+          const from = "2019-09-02";
+
+          it("returns false", () => {
+            expect(
+              calendarUtils.filterContributionDays(dailyData, from)
+            ).to.equal(false);
+          });
+        });
+
+        describe("when the contribution's date is not earlier than the starting point", () => {
+          const dailyData = {
+            attributes: {
+              class: "day",
+              "data-date": "2020-03-18"
+            }
+          };
+          const from = "2020-03-17";
+
+          it("returns true", () => {
+            expect(
+              calendarUtils.filterContributionDays(dailyData, from)
+            ).to.equal(true);
+          });
+        });
+      });
+    });
+  });
 });

--- a/src/utils/CalendarUtils/CalendarUtils.test.js
+++ b/src/utils/CalendarUtils/CalendarUtils.test.js
@@ -261,11 +261,11 @@ describe("CalendarUtils", () => {
               "data-date": "2019-09-01"
             }
           };
-          const from = "2019-09-02";
+          const startDate = "2019-09-02";
 
           it("returns false", () => {
             expect(
-              calendarUtils.filterContributionDays(dailyData, from)
+              calendarUtils.filterContributionDays(dailyData, startDate)
             ).to.equal(false);
           });
         });
@@ -277,11 +277,11 @@ describe("CalendarUtils", () => {
               "data-date": "2020-03-18"
             }
           };
-          const from = "2020-03-17";
+          const startDate = "2020-03-17";
 
           it("returns true", () => {
             expect(
-              calendarUtils.filterContributionDays(dailyData, from)
+              calendarUtils.filterContributionDays(dailyData, startDate)
             ).to.equal(true);
           });
         });

--- a/src/utils/GitHubUtils/GitHubUtils.js
+++ b/src/utils/GitHubUtils/GitHubUtils.js
@@ -72,13 +72,17 @@ export const mergeCalendarsContributions = (
     (weeklyData, weekIndex) => {
       weeklyData.children.forEach((dailyData, dayIndex) => {
         const dayDate = new Date(dailyData.attributes["data-date"]);
-        const timeFrameDateFrom = new Date(gitHubUserTimeFrame[0]);
-        const timeFrameDateTo = new Date(gitHubUserTimeFrame[1]);
+        const timeFrameDateFrom = gitHubUserTimeFrame
+          ? new Date(gitHubUserTimeFrame[0])
+          : dayDate;
+        const timeFrameDateTo = gitHubUserTimeFrame
+          ? new Date(gitHubUserTimeFrame[1])
+          : dayDate;
 
         if (
           dailyData.attributes.class === "day" &&
-          dayDate > timeFrameDateFrom &&
-          dayDate < timeFrameDateTo
+          dayDate >= timeFrameDateFrom &&
+          dayDate <= timeFrameDateTo
         ) {
           if (dailyData.attributes["data-count"]) {
             const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(

--- a/src/utils/GitHubUtils/GitHubUtils.js
+++ b/src/utils/GitHubUtils/GitHubUtils.js
@@ -150,10 +150,7 @@ export const getJsonFormattedCalendarAsync = async (
   proxyServerUrl,
   gitHubUsername
 ) => {
-  const userData = await getUserSvg(
-    proxyServerUrl,
-    Array.isArray(gitHubUsername) ? gitHubUsername[0] : gitHubUsername
-  );
+  const userData = await getUserSvg(proxyServerUrl, gitHubUsername);
 
   if (userData.error) {
     return {
@@ -165,7 +162,6 @@ export const getJsonFormattedCalendarAsync = async (
   return parse(userData.rawUserSvg.outerHTML).then(parsedGitHubCalendar => ({
     parsedCalendar: parsedGitHubCalendar,
     error: false,
-    errorMessage: null,
-    timeFrame: Array.isArray(gitHubUsername) ? gitHubUsername[1] : null
+    errorMessage: null
   }));
 };

--- a/src/utils/GitHubUtils/GitHubUtils.js
+++ b/src/utils/GitHubUtils/GitHubUtils.js
@@ -64,7 +64,7 @@ export const setEmptyCalendarValues = calendar => {
 export const mergeCalendarsContributions = (
   actualCalendar,
   gitHubUserJsonCalendar,
-  startDate
+  timeframe
 ) => {
   const copiedActualCalendar = javaScriptUtils.deepCopyObject(actualCalendar);
 
@@ -72,7 +72,7 @@ export const mergeCalendarsContributions = (
     (weeklyData, weekIndex) => {
       weeklyData.children
         .filter(dailyData =>
-          calendarUtils.filterContributionDays(dailyData, startDate)
+          calendarUtils.filterContributionDays(dailyData, timeframe)
         )
         .forEach((dailyData, dayIndex) => {
           const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(

--- a/src/utils/GitHubUtils/GitHubUtils.js
+++ b/src/utils/GitHubUtils/GitHubUtils.js
@@ -64,7 +64,7 @@ export const setEmptyCalendarValues = calendar => {
 export const mergeCalendarsContributions = (
   actualCalendar,
   gitHubUserJsonCalendar,
-  from
+  startDate
 ) => {
   const copiedActualCalendar = javaScriptUtils.deepCopyObject(actualCalendar);
 
@@ -72,7 +72,7 @@ export const mergeCalendarsContributions = (
     (weeklyData, weekIndex) => {
       weeklyData.children
         .filter(dailyData =>
-          calendarUtils.filterContributionDays(dailyData, from)
+          calendarUtils.filterContributionDays(dailyData, startDate)
         )
         .forEach((dailyData, dayIndex) => {
           const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(

--- a/src/utils/GitHubUtils/GitHubUtils.js
+++ b/src/utils/GitHubUtils/GitHubUtils.js
@@ -64,44 +64,35 @@ export const setEmptyCalendarValues = calendar => {
 export const mergeCalendarsContributions = (
   actualCalendar,
   gitHubUserJsonCalendar,
-  gitHubUserTimeFrame
+  from
 ) => {
   const copiedActualCalendar = javaScriptUtils.deepCopyObject(actualCalendar);
 
   gitHubUserJsonCalendar.children[0].children.forEach(
     (weeklyData, weekIndex) => {
       weeklyData.children.forEach((dailyData, dayIndex) => {
-        const dayDate = new Date(dailyData.attributes["data-date"]);
-        const timeFrameDateFrom = gitHubUserTimeFrame
-          ? new Date(gitHubUserTimeFrame[0])
-          : dayDate;
-        const timeFrameDateTo = gitHubUserTimeFrame
-          ? new Date(gitHubUserTimeFrame[1])
-          : dayDate;
+        const contributionDate = new Date(dailyData.attributes["data-date"]);
+        // Months and days should be ignored.
+        const isDate = dailyData.attributes.class === "day";
+        const skip = isDate && from && contributionDate <= new Date(from);
 
-        if (
-          dailyData.attributes.class === "day" &&
-          dayDate >= timeFrameDateFrom &&
-          dayDate <= timeFrameDateTo
-        ) {
-          if (dailyData.attributes["data-count"]) {
-            const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(
-              copiedActualCalendar,
-              weekIndex,
-              dayIndex
-            );
-            const totalDailyContributions =
-              Number(actualCalendarDailyData.attributes["data-count"]) +
-              Number(dailyData.attributes["data-count"]);
+        if (!skip) {
+          const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(
+            copiedActualCalendar,
+            weekIndex,
+            dayIndex
+          );
+          const totalDailyContributions =
+            Number(actualCalendarDailyData.attributes["data-count"]) +
+            Number(dailyData.attributes["data-count"]);
 
-            copiedActualCalendar.children[0].children[weekIndex].children[
-              dayIndex
-            ].attributes = {
-              ...actualCalendarDailyData.attributes,
-              "data-count": String(totalDailyContributions),
-              fill: calendarUtils.getFillColor(totalDailyContributions)
-            };
-          }
+          copiedActualCalendar.children[0].children[weekIndex].children[
+            dayIndex
+          ].attributes = {
+            ...actualCalendarDailyData.attributes,
+            "data-count": String(totalDailyContributions),
+            fill: calendarUtils.getFillColor(totalDailyContributions)
+          };
         }
       });
     }

--- a/src/utils/GitHubUtils/GitHubUtils.js
+++ b/src/utils/GitHubUtils/GitHubUtils.js
@@ -67,19 +67,18 @@ export const mergeCalendarsContributions = (
   gitHubUserTimeFrame
 ) => {
   const copiedActualCalendar = javaScriptUtils.deepCopyObject(actualCalendar);
-  console.log(gitHubUserTimeFrame);
 
   gitHubUserJsonCalendar.children[0].children.forEach(
     (weeklyData, weekIndex) => {
       weeklyData.children.forEach((dailyData, dayIndex) => {
         const dayDate = new Date(dailyData.attributes["data-date"]);
-        const timeFrame1Date = new Date(gitHubUserTimeFrame[0]);
-        const timeFrame2Date = new Date(gitHubUserTimeFrame[1]);
+        const timeFrameDateFrom = new Date(gitHubUserTimeFrame[0]);
+        const timeFrameDateTo = new Date(gitHubUserTimeFrame[1]);
 
         if (
           dailyData.attributes.class === "day" &&
-          dayDate > timeFrame1Date &&
-          dayDate < timeFrame2Date
+          dayDate > timeFrameDateFrom &&
+          dayDate < timeFrameDateTo
         ) {
           if (dailyData.attributes["data-count"]) {
             const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(

--- a/src/utils/GitHubUtils/GitHubUtils.js
+++ b/src/utils/GitHubUtils/GitHubUtils.js
@@ -70,13 +70,11 @@ export const mergeCalendarsContributions = (
 
   gitHubUserJsonCalendar.children[0].children.forEach(
     (weeklyData, weekIndex) => {
-      weeklyData.children.forEach((dailyData, dayIndex) => {
-        const contributionDate = new Date(dailyData.attributes["data-date"]);
-        // Months and days should be ignored.
-        const isDate = dailyData.attributes.class === "day";
-        const skip = isDate && from && contributionDate <= new Date(from);
-
-        if (!skip) {
+      weeklyData.children
+        .filter(dailyData =>
+          calendarUtils.filterContributionDays(dailyData, from)
+        )
+        .forEach((dailyData, dayIndex) => {
           const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(
             copiedActualCalendar,
             weekIndex,
@@ -93,8 +91,7 @@ export const mergeCalendarsContributions = (
             "data-count": String(totalDailyContributions),
             fill: calendarUtils.getFillColor(totalDailyContributions)
           };
-        }
-      });
+        });
     }
   );
 

--- a/src/utils/GitHubUtils/GitHubUtils.js
+++ b/src/utils/GitHubUtils/GitHubUtils.js
@@ -128,10 +128,7 @@ export const getJsonFormattedCalendarSync = async (
   proxyServerUrl,
   gitHubUsername
 ) => {
-  const userData = await getUserSvg(
-    proxyServerUrl,
-    Array.isArray(gitHubUsername) ? gitHubUsername[0] : gitHubUsername
-  );
+  const userData = await getUserSvg(proxyServerUrl, gitHubUsername);
 
   if (userData.error) {
     return {
@@ -145,8 +142,7 @@ export const getJsonFormattedCalendarSync = async (
   return {
     parsedCalendar,
     error: false,
-    errorMessage: null,
-    timeFrame: Array.isArray(gitHubUsername) ? gitHubUsername[1] : null
+    errorMessage: null
   };
 };
 

--- a/src/utils/GitHubUtils/GitHubUtils.test.js
+++ b/src/utils/GitHubUtils/GitHubUtils.test.js
@@ -53,7 +53,7 @@ describe("GitHubUtils", () => {
         "2019-04-19": 6
       }
     );
-    const timeFrame = null;
+    const timeframe = {};
 
     it("merges the `data-count` properties of the given calendars", () => {
       // Because of the previously created 5 and 6 contribution calendars.
@@ -62,7 +62,7 @@ describe("GitHubUtils", () => {
       const mergedCalendar = gitHubUtils.mergeCalendarsContributions(
         actualCalendar,
         userJsonCalendar,
-        timeFrame
+        timeframe
       );
 
       const actualDataCountValue = Number(

--- a/src/utils/GitHubUtils/GitHubUtils.test.js
+++ b/src/utils/GitHubUtils/GitHubUtils.test.js
@@ -53,6 +53,7 @@ describe("GitHubUtils", () => {
         "2019-04-19": 6
       }
     );
+    const timeFrame = null;
 
     it("merges the `data-count` properties of the given calendars", () => {
       // Because of the previously created 5 and 6 contribution calendars.
@@ -60,7 +61,8 @@ describe("GitHubUtils", () => {
 
       const mergedCalendar = gitHubUtils.mergeCalendarsContributions(
         actualCalendar,
-        userJsonCalendar
+        userJsonCalendar,
+        timeFrame
       );
 
       const actualDataCountValue = Number(

--- a/src/utils/GitLabUtils/GitLabUtils.js
+++ b/src/utils/GitLabUtils/GitLabUtils.js
@@ -15,14 +15,14 @@ const getDailyContributions = (gitLabCalendar, date) => {
 export const mergeCalendarsContributions = (
   actualCalendar,
   gitLabUserJsonCalendar,
-  startDate
+  timeframe
 ) => {
   const copiedActualCalendar = javaScriptUtils.deepCopyObject(actualCalendar);
 
   copiedActualCalendar.children[0].children.forEach((weeklyData, weekIndex) => {
     weeklyData.children
       .filter(dailyData =>
-        calendarUtils.filterContributionDays(dailyData, startDate)
+        calendarUtils.filterContributionDays(dailyData, timeframe)
       )
       .forEach((_, dayIndex) => {
         const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(

--- a/src/utils/GitLabUtils/GitLabUtils.js
+++ b/src/utils/GitLabUtils/GitLabUtils.js
@@ -15,14 +15,14 @@ const getDailyContributions = (gitLabCalendar, date) => {
 export const mergeCalendarsContributions = (
   actualCalendar,
   gitLabUserJsonCalendar,
-  from
+  startDate
 ) => {
   const copiedActualCalendar = javaScriptUtils.deepCopyObject(actualCalendar);
 
   copiedActualCalendar.children[0].children.forEach((weeklyData, weekIndex) => {
     weeklyData.children
       .filter(dailyData =>
-        calendarUtils.filterContributionDays(dailyData, from)
+        calendarUtils.filterContributionDays(dailyData, startDate)
       )
       .forEach((_, dayIndex) => {
         const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(

--- a/src/utils/GitLabUtils/GitLabUtils.js
+++ b/src/utils/GitLabUtils/GitLabUtils.js
@@ -22,13 +22,17 @@ export const mergeCalendarsContributions = (
   copiedActualCalendar.children[0].children.forEach((weeklyData, weekIndex) => {
     weeklyData.children.forEach((dailyData, dayIndex) => {
       const dayDate = new Date(dailyData.attributes["data-date"]);
-      const timeFrameDateFrom = new Date(gitLabUserTimeFrame[0]);
-      const timeFrameDateTo = new Date(gitLabUserTimeFrame[1]);
+      const timeFrameDateFrom = gitLabUserTimeFrame
+        ? new Date(gitLabUserTimeFrame[0])
+        : dayDate;
+      const timeFrameDateTo = gitLabUserTimeFrame
+        ? new Date(gitLabUserTimeFrame[1])
+        : dayDate;
 
       if (
         dailyData.attributes.class === "day" &&
-        dayDate > timeFrameDateFrom &&
-        dayDate < timeFrameDateTo
+        dayDate >= timeFrameDateFrom &&
+        dayDate <= timeFrameDateTo
       ) {
         if (dailyData.attributes["data-count"]) {
           const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(

--- a/src/utils/GitLabUtils/GitLabUtils.js
+++ b/src/utils/GitLabUtils/GitLabUtils.js
@@ -18,19 +18,17 @@ export const mergeCalendarsContributions = (
   gitLabUserTimeFrame
 ) => {
   const copiedActualCalendar = javaScriptUtils.deepCopyObject(actualCalendar);
-  console.log(gitLabUserTimeFrame);
+
   copiedActualCalendar.children[0].children.forEach((weeklyData, weekIndex) => {
     weeklyData.children.forEach((dailyData, dayIndex) => {
-      // console.log(dailyData.attributes["data-date"]);
-      // console.log(dailyData.attributes.class == "day");
       const dayDate = new Date(dailyData.attributes["data-date"]);
-      const timeFrame1Date = new Date(gitLabUserTimeFrame[0]);
-      const timeFrame2Date = new Date(gitLabUserTimeFrame[1]);
+      const timeFrameDateFrom = new Date(gitLabUserTimeFrame[0]);
+      const timeFrameDateTo = new Date(gitLabUserTimeFrame[1]);
 
       if (
         dailyData.attributes.class === "day" &&
-        dayDate > timeFrame1Date &&
-        dayDate < timeFrame2Date
+        dayDate > timeFrameDateFrom &&
+        dayDate < timeFrameDateTo
       ) {
         if (dailyData.attributes["data-count"]) {
           const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(

--- a/src/utils/GitLabUtils/GitLabUtils.js
+++ b/src/utils/GitLabUtils/GitLabUtils.js
@@ -20,13 +20,11 @@ export const mergeCalendarsContributions = (
   const copiedActualCalendar = javaScriptUtils.deepCopyObject(actualCalendar);
 
   copiedActualCalendar.children[0].children.forEach((weeklyData, weekIndex) => {
-    weeklyData.children.forEach((dailyData, dayIndex) => {
-      const contributionDate = new Date(dailyData.attributes["data-date"]);
-      // Months and days should be ignored.
-      const isDate = dailyData.attributes.class === "day";
-      const skip = isDate && from && contributionDate <= new Date(from);
-
-      if (!skip) {
+    weeklyData.children
+      .filter(dailyData =>
+        calendarUtils.filterContributionDays(dailyData, from)
+      )
+      .forEach((_, dayIndex) => {
         const actualCalendarDailyData = calendarUtils.getCalendarDataByIndexes(
           actualCalendar,
           weekIndex,
@@ -46,8 +44,7 @@ export const mergeCalendarsContributions = (
           "data-count": String(totalDailyContributions),
           fill: calendarUtils.getFillColor(totalDailyContributions)
         };
-      }
-    });
+      });
   });
 
   return copiedActualCalendar;

--- a/src/utils/GitLabUtils/GitLabUtils.test.js
+++ b/src/utils/GitLabUtils/GitLabUtils.test.js
@@ -25,9 +25,6 @@ describe("GitLabUtils", () => {
             "data-count"
           ]
         );
-        console.log("////////////start//////////////////");
-        console.log(updatedActualCalendar.children[0].children[0].children[0]);
-        console.log("////////////end//////////////////");
 
         expect(actualContributions).to.equal(expectedContributions);
       });

--- a/src/utils/GitLabUtils/GitLabUtils.test.js
+++ b/src/utils/GitLabUtils/GitLabUtils.test.js
@@ -25,6 +25,9 @@ describe("GitLabUtils", () => {
             "data-count"
           ]
         );
+        console.log("////////////start//////////////////");
+        console.log(updatedActualCalendar.children[0].children[0].children[0]);
+        console.log("////////////end//////////////////");
 
         expect(actualContributions).to.equal(expectedContributions);
       });

--- a/src/utils/GitLabUtils/GitLabUtils.test.js
+++ b/src/utils/GitLabUtils/GitLabUtils.test.js
@@ -7,6 +7,7 @@ describe("GitLabUtils", () => {
     const actualCalendar = testUtils.getFakeContributionsObjectWithDailyCounts({
       "2019-04-20": 10
     });
+    const timeframe = {};
 
     describe("when the user`s calendar contains contributions on the date that is presented in the actual calendar", () => {
       const gitLabUserJsonCalendar = {
@@ -18,7 +19,8 @@ describe("GitLabUtils", () => {
 
         const updatedActualCalendar = gitLabUtils.mergeCalendarsContributions(
           actualCalendar,
-          gitLabUserJsonCalendar
+          gitLabUserJsonCalendar,
+          timeframe
         );
         const actualContributions = Number(
           updatedActualCalendar.children[0].children[0].children[0].attributes[
@@ -40,7 +42,8 @@ describe("GitLabUtils", () => {
 
         const updatedActualCalendar = gitLabUtils.mergeCalendarsContributions(
           actualCalendar,
-          gitLabUserJsonCalendar
+          gitLabUserJsonCalendar,
+          timeframe
         );
         const actualContributions = Number(
           updatedActualCalendar.children[0].children[0].children[0].attributes[

--- a/src/utils/TestUtils/TestUtils.js
+++ b/src/utils/TestUtils/TestUtils.js
@@ -70,7 +70,7 @@ export const getFakeContributionsObjectWithDailyCounts = dailyDataWithContributi
 
 export const getTestParams = () => ({
   container: ".container",
-  gitHubUsers: ["gitHubUsername"],
-  gitLabUsers: ["gitLabUsername_one", "gitLabUsername_two"],
+  gitHubUsers: [{ name: "gitHubUsername", from: "2020-04-03" }],
+  gitLabUsers: [{ name: "gitLabUsername" }],
   proxyServerUrl: "https://proxy-server.com/"
 });


### PR DESCRIPTION
Issue #40 
Add support for timeframes, i.e. certain user's contributions to be shown for only a certain timeframe, defined in days.

Changes:
- [x] create logic for timeframes
- [x] update / rewrite tests
- [x] documentation

Example parameter:

> gitHubUsers: `[["tccemptyuser", ['2019-07-01','2019-08-04']], "tccemptyuser2"]`