### PR TITLE
Fix loading indicator

### DIFF
--- a/src/TeamContributionCalendar/TeamContributionCalendar.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.js
@@ -37,12 +37,18 @@ export default class TeamContributionCalendar {
       defaultUsers.gitHub
     );
 
-    this.updateHeader({
-      isLoading: false
-    });
-
     if (defaultUserData.error) {
+      this.updateHeader({
+        isLoading: false
+      });
+
       throw new Error(defaultUserData.errorMessage);
+    }
+
+    if (!this.users.gitHub.length && !this.users.gitLab.length) {
+      this.updateHeader({
+        isLoading: false
+      });
     }
 
     const defaultUserEmptyCalendar = gitHubUtils.setEmptyCalendarValues(

--- a/src/TeamContributionCalendar/TeamContributionCalendar.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.js
@@ -37,11 +37,11 @@ export default class TeamContributionCalendar {
       defaultUsers.gitHub
     );
 
-    if (defaultUserData.error) {
-      this.updateHeader({
-        isLoading: false
-      });
+    this.updateHeader({
+      isLoading: false
+    });
 
+    if (defaultUserData.error) {
       throw new Error(defaultUserData.errorMessage);
     }
 

--- a/src/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -122,14 +122,22 @@ describe("TeamContributionCalendar", () => {
       ).to.equal(true);
     });
 
-    it("hides the loading indicator", async () => {
-      await teamContributionCalendar.renderBasicAppearance();
+    describe("when no users passed via the configs", () => {
+      it("hides the loading indicator", async () => {
+        const calendarWithoutUsers = new TeamContributionCalendar(
+          ".container",
+          [],
+          []
+        );
 
-      expect(
-        updateHeaderStub.calledWithExactly({
-          isLoading: false
-        })
-      ).to.equal(true);
+        await calendarWithoutUsers.renderBasicAppearance();
+
+        expect(
+          updateHeaderStub.calledWithExactly({
+            isLoading: false
+          })
+        ).to.equal(true);
+      });
     });
 
     describe("when the fetch fails", () => {
@@ -140,6 +148,18 @@ describe("TeamContributionCalendar", () => {
 
       beforeEach(() => {
         getJsonFormattedCalendarSyncStub.returns(defaultUserData);
+      });
+
+      it("hides the loading indicator", async () => {
+        try {
+          await teamContributionCalendar.renderBasicAppearance();
+        } catch (err) {
+          expect(
+            updateHeaderStub.calledWithExactly({
+              isLoading: false
+            })
+          ).to.equal(true);
+        }
       });
 
       it("throws the error", () => {

--- a/src/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -122,7 +122,7 @@ describe("TeamContributionCalendar", () => {
       ).to.equal(true);
     });
 
-    describe("when no users passed via the configs", () => {
+    describe("when no users are passed via the configs", () => {
       it("hides the loading indicator", async () => {
         const calendarWithoutUsers = new TeamContributionCalendar(
           ".container",

--- a/src/TeamContributionCalendar/TeamContributionCalendar.test.js
+++ b/src/TeamContributionCalendar/TeamContributionCalendar.test.js
@@ -67,6 +67,7 @@ describe("TeamContributionCalendar", () => {
   describe("renderBasicAppearance", () => {
     let renderSvgStub;
     let renderHeaderStub;
+    let updateHeaderStub;
     let getJsonFormattedCalendarSyncStub;
     let setEmptyCalendarValuesStub;
 
@@ -90,6 +91,11 @@ describe("TeamContributionCalendar", () => {
       renderHeaderStub = sandbox.stub(
         TeamContributionCalendar.prototype,
         "renderHeader"
+      );
+
+      updateHeaderStub = sandbox.stub(
+        TeamContributionCalendar.prototype,
+        "updateHeader"
       );
     });
 
@@ -116,31 +122,24 @@ describe("TeamContributionCalendar", () => {
       ).to.equal(true);
     });
 
-    describe("when the fetch fails", () => {
-      let updateHeaderStub;
+    it("hides the loading indicator", async () => {
+      await teamContributionCalendar.renderBasicAppearance();
 
+      expect(
+        updateHeaderStub.calledWithExactly({
+          isLoading: false
+        })
+      ).to.equal(true);
+    });
+
+    describe("when the fetch fails", () => {
       const defaultUserData = {
         error: true,
         errorMessage: "Could not fetch the calendar of the default user."
       };
 
       beforeEach(() => {
-        updateHeaderStub = sandbox.stub(
-          TeamContributionCalendar.prototype,
-          "updateHeader"
-        );
-
         getJsonFormattedCalendarSyncStub.returns(defaultUserData);
-      });
-
-      it("modifies the header's loading state", () => {
-        return teamContributionCalendar.renderBasicAppearance().catch(() => {
-          expect(
-            updateHeaderStub.calledWithExactly({
-              isLoading: false
-            })
-          ).to.equal(true);
-        });
       });
 
       it("throws the error", () => {


### PR DESCRIPTION
The loading indicator should be hidden regardless of the outcome of the initial fetch. Otherwise, if no user arrays are passed to the package, the loading indicator never stops.